### PR TITLE
Add fast-h3-live: continuous FL2VA chain from one prompt

### DIFF
--- a/fast-h3-live/.dockerignore
+++ b/fast-h3-live/.dockerignore
@@ -1,0 +1,24 @@
+# Python caches and local environments
+__pycache__/
+*.py[cod]
+*.egg-info/
+.pytest_cache/
+.ruff_cache/
+.venv/
+venv/
+
+# Editor and operating-system state
+.vscode/
+.idea/
+*.swp
+.DS_Store
+Thumbs.db
+
+# Source-control metadata and local model assets
+.git/
+.gitignore
+weights/
+
+# Client-side code; nothing in the image imports it
+client/
+

--- a/fast-h3-live/PR_NOTES.md
+++ b/fast-h3-live/PR_NOTES.md
@@ -1,0 +1,95 @@
+# fast-h3-live — continuous FL2VA chain from one prompt
+
+A sibling model to `fast-h3/`, left untouched. Same engine, same 148 GB
+checkpoint, same solved infrastructure — but instead of a queue of independent
+clips separated by a black flush, this channel chains clips into **one
+continuous video-and-audio stream from a single held prompt**, with no
+re-prompting. This is our validated FL2VA-chaining logic (the one that produced
+the good 30 s bear video from one prompt) housed in this repo's runtime
+scaffolding.
+
+## What it does
+
+- `set_prompt` holds a prompt; `start` begins an open-ended chain; `stop` ends
+  it; `set_prompt` again mid-run steers the stream at the next clip.
+- Clip 0 is **T2VA**. Every clip after is **FL2VA**, anchored on the previous
+  clip's last frame, so the scene carries forward off the one prompt.
+- Consecutive clips are **stitched** at the seam so the result plays as one
+  video, not a sequence of cuts:
+  - **linearfade** — a linear-light crossfade with complementary weights and a
+    ramped local exposure match (kills the sRGB "flash"; validated monotonic).
+  - **per-clip color-match** locked to clip 0's last-frame mean (exposure can't
+    ratchet across a long chain — the drift that blew the bear video to white).
+  - **equal-power audio overlap-add** across the same window.
+- **Double-buffered**: a producer builds clips ahead into a bounded queue while
+  the consumer streams and stitches, so generation can stay ahead of playback.
+
+## Files
+
+New model logic:
+- `live_h3.py` — `ReactorModel`: full control surface + held-prompt indefinite
+  producer/consumer chain.
+- `live_h3_backend.py` — `fast-h3`'s backend **plus** an FL2VA `anchor_image`,
+  the last frame returned for the next anchor, and **both** the T2VA and FL2VA
+  compile shapes warmed at load.
+- `live_h3_seam.py` — the seam math (pure numpy, GPU-free): color-match lock,
+  linear-light blend, equal-power audio.
+- `live_h3_types.py` — the stream contract (tracks + messages).
+- `live_h3_assets.py` — config parsing / weights validation (their assets with
+  the queue sizes replaced by the seam + buffer knobs).
+- `reactor.yaml`, `live_h3.yaml` — mirror `fast-h3`'s manifest and recipe;
+  only name/import/description and the queue→chain knobs differ.
+
+Copied verbatim from `fast-h3/` (with parity tests that fail if they drift):
+- `sitecustomize.py`, `requirements.txt`, `live_h3_clip_plan.py`
+  (← `fasth3_clip_plan.py`).
+
+## Timing fixes carried over (this was our bimodal cause)
+
+- **256-token prompt pad** — one compiled shape for every prompt; without it a
+  novel prompt length recompiles the transformer (~23 s) mid-stream.
+- **Dynamo recompile-limit raise** — in the parent and, via `sitecustomize.py`
+  on `PYTHONPATH`, in every spawned engine worker.
+- **Warm BOTH T2VA and FL2VA shapes at load** — the FL2VA anchor adds keyframe
+  rows to the packed sequence, a distinct compile shape; unwarmed, the first
+  continuation clip stalls ~20 s. `_warmup` now builds both paths per shape.
+
+## CPU checks (this branch)
+
+`PYTHONPATH=. python -m pytest tests/ -q` → **50 passed**. `py_compile` clean on
+all files. Covered without a GPU:
+- seam: linearfade monotonic / no midpoint flash / endpoints approach each clip;
+  color-match locks to clip 0's mean, preserves intra-clip variation, and does
+  **not** ratchet across a chain; audio overlap equal-power, no int16 wrap.
+- chain end-to-end (fake backend): one held prompt drives an indefinite chain;
+  clip 0 T2VA, every clip after FL2VA-anchored; seed advances per clip;
+  `set_prompt` steers mid-stream; `stop`/restart/`reset`; A/V locked slice for
+  slice; the seam removes exactly one overlap per boundary (`C*N-(C-1)*k`).
+- schema renders; command set, tracks, messages, moderation, bounds; manifest
+  (name=folder, bare semver, runtime 3.2.6, import resolves, no weights);
+  shared-file parity with `fast-h3`; sitecustomize arch list ↔ manifest.
+
+## Honest limits — NOT yet GPU-validated
+
+- **Chaining quality from one prompt** — reproduces the bear video; validated
+  previously on GPU with this exact seam + color-match + FL2VA-anchor logic.
+- **Gap-free live playback** — **NOT** GPU-validated on this branch. The bimodal
+  6 s/12 s per-clip timing we hit before should resolve via the 256-pad +
+  recompile-limit fixes carried over here, but that is **unconfirmed** until a
+  GPU pass. `live_h3.yaml` ships short 5.167 s clips (max double-buffer
+  headroom) at 768p; whether an FL2VA clip builds inside the playout budget at
+  768p is exactly what a GPU pass must measure.
+- **FL2VA is undistilled on this checkpoint.** FL2VA rides the base path, not
+  the 4-step DMD2 distillation; long-run quality/drift at 768p over many clips
+  is a real risk. Genuine motion continuity across seams needs a distilled
+  `transformer_ref` (Ref2VA) partition — which the DataFree preview checkpoint
+  does not contain. The seam blend hides the *appearance* discontinuity, not the
+  *momentum* reset; post-hoc tricks (longoverlap, flowwarp) were tried and lost
+  to linearfade.
+
+## Needs a GPU validation pass
+
+1. FL2VA clip build time at 768p vs the playout budget → is the stream gap-free?
+   If not, the levers are shorter clips, a smaller canvas, or a wider crossfade.
+2. Long-run FL2VA quality/drift over many minutes of chain.
+3. `recording.enabled` can be turned on once (1) confirms continuity.

--- a/fast-h3-live/live_h3.py
+++ b/fast-h3-live/live_h3.py
@@ -1,0 +1,724 @@
+"""Live FastH3: one prompt, an endless continuously-stitched video-and-audio stream.
+
+FastH3 is MiniMax-H3 distilled to four transformer forwards. The hard-cut
+``fast-h3`` channel plays independent clips with a black flush between them; this
+channel instead **chains** them into one continuous stream from a single prompt:
+`set_prompt` holds a prompt, `start` begins, and from then on the model generates
+clip after clip with no further input — the first is text-to-video-and-audio, and
+every clip after is FL2VA-anchored on the previous clip's last frame, so the scene
+carries forward. Consecutive clips are stitched at their seam (a linear-light
+crossfade with per-clip color-match, and an equal-power audio overlap), so the
+result plays as one video rather than a sequence of cuts. `stop` ends it; a
+mid-run `set_prompt` swaps the held prompt in for the next clip, steering the
+stream without interrupting it.
+
+The unit of work is a whole clip, not a frame, which is why this subclasses
+``ReactorModel`` and owns its own ``run()`` loop rather than using
+``ReactorPipeline``. Generation runs ahead of playout in a bounded queue
+(double-buffering), so while one clip streams the next is already building — the
+only way clip generation can keep ahead of real-time playback.
+
+Layout:
+  * ``live_h3_types.py``      — everything a client sees (tracks, messages).
+  * ``live_h3_backend.py``    — the FastVideo engine, FL2VA anchor, worker thread.
+  * ``live_h3_seam.py``       — the seam stitch (color-match, linear-light blend).
+  * ``live_h3_assets.py``     — config parsing and weights validation.
+  * ``live_h3_clip_plan.py``  — clip geometry (lengths, frame counts, canvases).
+  * ``live_h3.yaml``          — the generation recipe, seam knobs, weight layout.
+
+``sitecustomize.py`` next to this file is the shared interpreter-wide fix (dynamo
+recompile limits, VSA arch gate) the manifest puts on ``PYTHONPATH``.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import contextlib
+from pathlib import Path
+
+import numpy as np
+from reactor_runtime import (
+    ClientInfo,
+    InputField,
+    ReactorModel,
+    connected,
+    event,
+    get_weights_path,
+    session_ended,
+    session_started,
+)
+from reactor_runtime.log import get_logger
+
+import live_h3_clip_plan as clip_plan
+import live_h3_seam as seam
+from live_h3_assets import load_config, require_weights, resolve_model_path
+from live_h3_backend import OUTPUT_SAMPLE_RATE, LiveH3Backend
+from live_h3_types import (
+    MAX_PROMPT_CHARS,
+    CanvasAccepted,
+    ClipComplete,
+    ClipLengthAccepted,
+    CommandError,
+    LiveH3Output,
+    PromptAccepted,
+    SeedAccepted,
+    SessionReset,
+    StateUpdate,
+    StreamStarted,
+    StreamStopped,
+)
+
+logger = get_logger(__name__)
+
+FRAME_RATE = clip_plan.FPS
+
+# Exact because 48000 / 24 divides evenly: one video frame is 2000 audio samples,
+# so seam slicing lands on sample boundaries with no rounding drift.
+SAMPLES_PER_FRAME = OUTPUT_SAMPLE_RATE // FRAME_RATE
+
+# The clip-length range, rendered once so the command text and the schema's own
+# bounds can never disagree.
+_CLIP_RANGE = f"{clip_plan.MIN_SECONDS_PUBLISHED:g} and {clip_plan.MAX_SECONDS_PUBLISHED:g}"
+
+# Frames per emitted slice. The runtime recorder's feed queue cannot absorb
+# one-second bursts, and the emitter is a metronome either way, so smaller
+# slices cost nothing.
+EMIT_FRAMES = 3
+
+# Idle re-check and job-poll granularity. Runs on the event loop, so this is a
+# scheduling granularity, not a busy-wait.
+POLL_SECONDS = 0.05
+
+
+class LiveH3(ReactorModel):
+    """Drive an endless continuously-stitched clip chain from one held prompt."""
+
+    # Pinned: the emitter is a strict 24 fps metronome and every emit omits
+    # `compute_time`, which is exactly the "unmeasured" path this rate tags.
+    # Measuring instead re-estimates the rate from observed timing, whose wobble
+    # both drops frames while converging and drifts video against the
+    # sample-clocked audio.
+    fps = FRAME_RATE
+    # Two seconds of transport-side tolerance at 24 fps, so a hiccup dents the
+    # buffer instead of dropping frames.
+    buffer_size = 48
+
+    # ------------------------------------------------------------------ load
+
+    def load(self, config_path: Path | None) -> None:
+        """Parse the config, validate the weights, and build the warm engine.
+
+        Runs once at startup, before any session. The runtime marks the pod
+        ready only when this returns, so the backend's warm-up (both the T2VA
+        and the FL2VA compile shape) means a deployed pod never builds a cold
+        clip — the first continuation would otherwise stall ~20 s.
+
+        Args:
+            config_path: Path to ``live_h3.yaml``; its ``inference`` block is the
+                generation recipe and the seam knobs, and its ``runtime`` block
+                holds the weight layout and the engine shape.
+        """
+        self.config = load_config(config_path)
+        weights = get_weights_path()
+        model_path = resolve_model_path(self.config, weights)
+        require_weights(weights, model_path)
+
+        self.backend = LiveH3Backend(self.config, model_path)
+        # Session-scoped state exists before the first session, so a command
+        # racing ahead of `@session_started` reads defaults, never garbage.
+        self._reset_session_state()
+        self.backend.load()
+        logger.info(
+            "live fast-h3 loaded",
+            clip_frames=self.config.clip_frames,
+            crossfade_frames=self.config.crossfade_frames,
+            color_match=self.config.color_match,
+            buffer_depth=self.config.buffer_depth,
+        )
+
+    # -------------------------------------------------------- session state
+
+    def _reset_session_state(self) -> None:
+        """Return every session-scoped field to its default.
+
+        Called once at ``load()`` and at every ``@session_started``, which is
+        what keeps one session from ever observing another's prompt, conditions,
+        or a chain it did not start.
+        """
+        # Conditions the next chain snapshots at `start`.
+        self._prompt: str = ""
+        self._seed: int = self.config.seed
+        self._clip_frames: int = self.config.clip_frames
+        self._aspect: str = self.config.aspect
+
+        # Chain lifecycle. ``_streaming`` is owned by the run loop; the two
+        # request flags are how a command asks a running chain to unwind —
+        # ``_stop_requested`` cuts it (a `stream_stopped` follows), and
+        # ``_reset_requested`` additionally suppresses that message because
+        # `reset` reports its own `session_reset`.
+        self._streaming: bool = False
+        self._stop_requested: bool = False
+        self._reset_requested: bool = False
+
+        # Progress, mirrored so a `state_update` is a complete snapshot. The
+        # pacing clock lives here too, spanning a whole chain so blocks are
+        # emitted gap-free rather than each clip re-starting the metronome.
+        self._clips_emitted: int = 0
+        self._frames_sent: int = 0
+        self._seconds_sent: float = 0.0
+        self._clock_start: float | None = None
+        self._frames_paced: int = 0
+
+    def _canvas(self) -> tuple[int, int]:
+        """The ``(height, width)`` this session generates at."""
+        return clip_plan.canvas_for_choice(self._aspect)
+
+    def _valid_commands(self) -> list[str]:
+        """The commands the session would accept right now.
+
+        A chain locks the canvas, the seed and the clip length (they are snapped
+        at `start` and a mid-chain change would recompile), and offers `stop`; an
+        idle session offers `set_canvas` and — once a prompt is held — `start`.
+        """
+        commands = {"get_state", "set_prompt", "reset"}
+        if self._streaming:
+            commands.add("stop")
+        else:
+            commands |= {"set_seed", "set_clip_seconds", "set_canvas"}
+            if self._prompt.strip():
+                commands.add("start")
+        return sorted(commands)
+
+    def _snapshot(self) -> StateUpdate:
+        """Everything a client can observe, in one message.
+
+        The single source of the snapshot: `state_update` broadcasts it, a
+        joining client is greeted with it, and `get_state` answers with it.
+        Built once here so those three can never disagree.
+        """
+        height, width = self._canvas()
+        return StateUpdate(
+            prompt=self._prompt,
+            streaming=self._streaming,
+            clip_seconds=round(clip_plan.seconds_for_frames(self._clip_frames), 3),
+            clip_seconds_min=clip_plan.MIN_SECONDS_PUBLISHED,
+            clip_seconds_max=clip_plan.MAX_SECONDS_PUBLISHED,
+            seed=self._seed,
+            aspect=self._aspect,
+            width=width,
+            height=height,
+            clips_emitted=self._clips_emitted,
+            seconds_sent=round(self._seconds_sent, 2),
+            valid_commands=self._valid_commands(),
+        )
+
+    async def _send_state_update(self) -> None:
+        """Broadcast the snapshot to every connected client."""
+        await self.send(self._snapshot())
+
+    async def _refuse(self, command: str, reason: str) -> None:
+        """Reject a command: tell every client, and leave its reply bodyless.
+
+        A handler returns only the message its annotation names, and reports a
+        failure by broadcasting `command_error` and returning without a value.
+        The runtime answers that with a correlated bodyless acknowledgement, so
+        an awaiting client resolves rather than hanging — and unlike a raised
+        runtime ``CommandError``, whose failure frame is withheld from v0
+        clients, the broadcast reaches every SDK generation.
+        """
+        logger.info("command refused", command=command, reason=reason)
+        await self.send(CommandError(command=command, reason=reason))
+
+    # ------------------------------------------------------------ lifecycle
+
+    @session_started
+    async def on_session_started(self) -> None:
+        """Clear the prompt and every condition so a new session inherits nothing."""
+        self._stop_requested = True  # unwind any chain the run loop still holds
+        self._reset_session_state()
+
+    @session_ended
+    async def on_session_ended(self) -> None:
+        """Cut the chain; the only hook guaranteed to fire on every path."""
+        self._stop_requested = True
+
+    @connected
+    async def on_connect(self, client: ClientInfo) -> None:
+        """Greet the joining client with the full state.
+
+        Addressed rather than broadcast: the clients already watching have this,
+        and a late joiner needs it without replaying every command.
+        """
+        await client.send(self._snapshot())
+
+    # ------------------------------------------------------------- commands
+
+    @event(
+        name="set_prompt",
+        description=(
+            "Hold a prompt for the chain to generate from. Set before `start` it "
+            "is the chain's prompt; set during a run it swaps in for the next "
+            "clip generated, steering the stream without interrupting it — the "
+            "single held prompt then keeps driving generation with no further "
+            "input. Replies `prompt_accepted` and emits `state_update`, or "
+            "`command_error` when the prompt is empty."
+        ),
+    )
+    async def set_prompt(
+        self,
+        prompt: str = InputField(
+            default="",
+            max_length=MAX_PROMPT_CHARS,
+            moderate=True,
+            description=(
+                "What the stream should show, up to 800 characters. One prompt "
+                "drives the whole chain; there is no re-prompting per clip unless "
+                "you choose to steer with another `set_prompt`."
+            ),
+        ),
+    ) -> PromptAccepted:
+        """Hold a prompt; the running chain, if any, picks it up on its next clip."""
+        prompt = prompt.strip()
+        if not prompt:
+            await self._refuse("set_prompt", "The prompt is empty; the chain needs one.")
+            return None
+        self._prompt = prompt
+        applied_live = self._streaming
+        await self._send_state_update()
+        return PromptAccepted(prompt=self._prompt, applied_live=applied_live)
+
+    @event(
+        name="start",
+        description=(
+            "Begin the continuous chain from the held prompt. The first clip is "
+            "text-to-video-and-audio; every clip after is anchored on the "
+            "previous clip's last frame and stitched onto it, so the stream runs "
+            "indefinitely off the one prompt until `stop`. Emits `stream_started` "
+            "and `state_update`, or `command_error` when a chain is already "
+            "running or no prompt is held."
+        ),
+    )
+    async def start(self) -> None:
+        """Arm the chain; the run loop begins generating and streaming it."""
+        if self._streaming:
+            await self._refuse("start", "A chain is already running; send `stop` first.")
+            return
+        if not self._prompt.strip():
+            await self._refuse("start", "Set a prompt with `set_prompt` before starting.")
+            return
+        self._stop_requested = False
+        self._reset_requested = False
+        self._clips_emitted = 0
+        self._frames_sent = 0
+        self._seconds_sent = 0.0
+        self._clock_start = None
+        self._frames_paced = 0
+        self._streaming = True
+        height, width = self._canvas()
+        await self.send(
+            StreamStarted(
+                prompt=self._prompt,
+                aspect=self._aspect,
+                width=width,
+                height=height,
+                clip_seconds=round(clip_plan.seconds_for_frames(self._clip_frames), 3),
+                seed=self._seed,
+            )
+        )
+        await self._send_state_update()
+
+    @event(
+        name="stop",
+        description=(
+            "End the running chain. Generation stops, whatever is queued on the "
+            "output tracks is dropped, and the picture goes to black within a "
+            "fraction of a second. A later `start` begins a fresh chain from the "
+            "held prompt. Emits `stream_stopped` and `state_update`, or "
+            "`command_error` when no chain is running."
+        ),
+    )
+    async def stop(self) -> None:
+        """Ask the run loop to cut the chain."""
+        if not self._streaming:
+            await self._refuse("stop", "No chain is running.")
+            return
+        self._stop_requested = True
+
+    @event(
+        name="set_seed",
+        description=(
+            "Set the seed the next chain's first clip generates from; each "
+            "continuation advances it by one, so re-running the same prompt "
+            "reproduces the same stream. Takes effect on the next `start` — a "
+            "running chain keeps its seed. Emits `seed_accepted` and "
+            "`state_update`."
+        ),
+    )
+    async def set_seed(
+        self,
+        seed: int = InputField(
+            default=1000,
+            ge=0,
+            description=(
+                "Seed for the next chain. Reproduction is close rather than "
+                "exact: the deployment runs fused kernels that can reorder "
+                "arithmetic."
+            ),
+        ),
+    ) -> SeedAccepted:
+        """Set the seed the next chain starts from."""
+        self._seed = int(seed)
+        await self._send_state_update()
+        return SeedAccepted(seed=self._seed)
+
+    @event(
+        name="set_clip_seconds",
+        description=(
+            "Set the length of each clip the chain generates. Shorter clips seam "
+            "more often but keep generation further ahead of playback; longer "
+            "ones seam less. The value is snapped to the nearest length the model "
+            "can produce, so read the effective one back from "
+            "`clip_length_accepted`. Takes effect on the next `start` — a running "
+            "chain keeps its length so the compiled shape never changes mid-"
+            "stream. Emits `clip_length_accepted` and `state_update`."
+        ),
+    )
+    async def set_clip_seconds(
+        self,
+        seconds: float = InputField(
+            default=clip_plan.MAX_SECONDS_PUBLISHED,
+            ge=clip_plan.MIN_SECONDS_PUBLISHED,
+            le=clip_plan.MAX_SECONDS_PUBLISHED,
+            description=(
+                f"Clip length in seconds, between {_CLIP_RANGE}. Snapped to the "
+                "nearest length the model can produce, so the value that takes "
+                "effect can differ slightly; `state_update.clip_seconds` always "
+                "carries the one in force."
+            ),
+        ),
+    ) -> ClipLengthAccepted:
+        """Set the per-clip length the next chain generates at."""
+        self._clip_frames = clip_plan.frames_for_seconds(float(seconds))
+        await self._send_state_update()
+        return ClipLengthAccepted(
+            clip_seconds=round(clip_plan.seconds_for_frames(self._clip_frames), 3),
+            frames=self._clip_frames,
+        )
+
+    @event(
+        name="set_canvas",
+        description=(
+            "Choose the aspect ratio of `main_video`. The video track keeps one "
+            "size for a whole chain, so this is only valid while no chain is "
+            "running. Emits `canvas_accepted`, carrying the exact pixel size, and "
+            "`state_update`, or `command_error` while a chain is running or when "
+            "the ratio is not one this model offers."
+        ),
+    )
+    async def set_canvas(
+        self,
+        aspect: str = InputField(
+            default="16:9",
+            choices=list(clip_plan.ASPECT_CHOICES),
+            description=(
+                "Aspect ratio of `main_video`. `canvas_accepted` and "
+                "`state_update` report the width and height in pixels it resolves "
+                "to."
+            ),
+        ),
+    ) -> CanvasAccepted:
+        """Set the session's canvas; refused while a chain is running."""
+        if self._streaming:
+            await self._refuse(
+                "set_canvas",
+                "The canvas is fixed while a chain is running; `stop` first.",
+            )
+            return None
+        try:
+            height, width = clip_plan.canvas_for_choice(aspect)
+        except ValueError as error:
+            await self._refuse("set_canvas", str(error))
+            return None
+        self._aspect = aspect
+        await self._send_state_update()
+        return CanvasAccepted(aspect=aspect, width=width, height=height)
+
+    @event(
+        name="reset",
+        description=(
+            "Return every condition to its default, clear the held prompt, cut "
+            "any running chain, and clear the output tracks. A running chain is "
+            "cut with a `stream_stopped` to mark it. Valid at any time. Replies "
+            "`session_reset` and emits `state_update`."
+        ),
+    )
+    async def reset(self) -> SessionReset:
+        """Clear the session back to its defaults, cutting any running chain."""
+        was_streaming = self._streaming
+        if self._streaming:
+            self._reset_requested = True
+            self._stop_requested = True
+        self._prompt = ""
+        self._seed = self.config.seed
+        self._clip_frames = self.config.clip_frames
+        self._aspect = self.config.aspect
+        self.output.flush()
+        await self._send_state_update()
+        return SessionReset(was_streaming=was_streaming)
+
+    @event(
+        name="get_state",
+        description=(
+            "Return a snapshot of everything the session exposes: the held "
+            "prompt, the conditions in force, whether a chain is running, "
+            "progress counters, and the commands that are valid right now. The "
+            "same payload the model broadcasts as `state_update`. Valid at any "
+            "time."
+        ),
+    )
+    async def get_state(self) -> StateUpdate:
+        """Answer with the same snapshot `state_update` broadcasts."""
+        return self._snapshot()
+
+    # ------------------------------------------------------------- run loop
+
+    async def run(self) -> None:
+        """The model's control loop: park without an audience, serve with one.
+
+        Nothing here may raise: an exception out of ``run()`` is an
+        unrecoverable crash of the whole model loop, not the end of one session,
+        so ``_serve`` owns its own failure reporting.
+        """
+        while True:
+            await self.connected.wait()
+            await self._serve()
+
+    async def _serve(self) -> None:
+        """Run an armed chain while an audience is connected, else idle.
+
+        Generation is gated on having an audience: with nobody connected no chain
+        runs, and the loop parks back in ``run()``.
+        """
+        while self.connected.is_set():
+            try:
+                if self._streaming:
+                    await self._run_chain()
+                else:
+                    await asyncio.sleep(POLL_SECONDS)
+            except Exception:  # noqa: BLE001 — the model loop must survive anything
+                logger.exception("error in the live fast-h3 serve loop")
+                self._streaming = False
+                self.output.flush()
+                await asyncio.sleep(POLL_SECONDS)
+
+    async def _run_chain(self) -> None:
+        """Generate and stream one continuous chain until it is stopped.
+
+        A producer task builds clips ahead into a bounded queue (double-buffering
+        — while one clip streams the next is already on the worker), and the
+        consumer here stitches each onto the last and paces it out. The chain
+        ends on `stop`, `reset`, or a lost audience; it then flushes to black and
+        reports how it ended, unless `reset` (which reports its own).
+        """
+        queue: asyncio.Queue = asyncio.Queue(maxsize=self.config.buffer_depth)
+        self._producer_error: BaseException | None = None
+        height, width = self._canvas()
+        producer = asyncio.create_task(self._producer(queue, height, width, base_seed=self._seed))
+        try:
+            await self._consumer(queue)
+        finally:
+            producer.cancel()
+            with contextlib.suppress(asyncio.CancelledError):
+                await producer
+            self.output.flush()
+            self._streaming = False
+
+        if self._producer_error is not None:
+            logger.error("chain ended on a generation failure", error=str(self._producer_error))
+        if not self._reset_requested:
+            await self.send(
+                StreamStopped(
+                    clips_emitted=self._clips_emitted,
+                    seconds_sent=round(self._seconds_sent, 2),
+                )
+            )
+        await self._send_state_update()
+
+    async def _producer(
+        self, queue: asyncio.Queue, height: int, width: int, *, base_seed: int
+    ) -> None:
+        """Build clips ahead of playout, color-matched and anchored, into ``queue``.
+
+        The first clip is T2VA; every clip after passes the previous clip's
+        (color-matched) last frame as the FL2VA anchor, which is what carries the
+        scene across the seam. The color-match reference is locked once to clip
+        0's last frame and held for the whole chain, so exposure cannot ratchet.
+        A ``None`` sentinel is always the last thing put, so the consumer unwinds
+        even on stop or failure.
+        """
+        from PIL import Image
+
+        loop = asyncio.get_running_loop()
+        index = 0
+        target_rgb: np.ndarray | None = None
+        anchor = None
+        try:
+            while not self._stop_requested and self.connected.is_set():
+                prompt = self._prompt  # held; a mid-chain set_prompt steers here
+                job = self.backend.submit(
+                    frames=self._clip_frames,
+                    prompt=prompt,
+                    seed=base_seed + index,
+                    height=height,
+                    width=width,
+                    anchor_image=anchor,
+                )
+                while not job.done.is_set():
+                    if self._stop_requested or not self.connected.is_set():
+                        job.cancelled = True
+                        return
+                    await asyncio.sleep(POLL_SECONDS)
+                if job.error is not None:
+                    self._producer_error = job.error
+                    return
+                frames_list, samples = job.result
+                # Off-loop numpy work: stacking a clip's frames is not trivial at
+                # 768p, and blocking the event loop would stutter the emitter.
+                frames = await loop.run_in_executor(
+                    None, self._post_process, index, frames_list, target_rgb
+                )
+                if target_rgb is None:
+                    target_rgb = seam.reference_rgb(frames[-1])
+                anchor = Image.fromarray(frames[-1]).convert("RGB")
+                await queue.put((index, prompt, frames, samples))
+                index += 1
+        except Exception as error:  # noqa: BLE001 — handed to the consumer's caller
+            self._producer_error = error
+            logger.exception("live fast-h3 producer raised")
+        finally:
+            await queue.put(None)
+
+    def _post_process(
+        self, index: int, frames_list: list, target_rgb: np.ndarray | None
+    ) -> np.ndarray:
+        """Stack a clip's frames and color-match continuation clips to clip 0.
+
+        Runs in a thread executor. Clip 0 is left as generated (it sets the
+        reference); every clip after is shifted by one per-channel offset onto
+        that reference.
+        """
+        frames = np.ascontiguousarray(np.stack(frames_list))
+        if index > 0 and self.config.color_match == "per_clip" and target_rgb is not None:
+            frames = seam.color_match_to_reference(frames, target_rgb)
+        return frames
+
+    async def _consumer(self, queue: asyncio.Queue) -> None:
+        """Stitch each built clip onto the last and pace the result out.
+
+        Each clip holds back its last ``crossfade_frames`` as the seam tail; when
+        the next clip arrives, that tail is crossfaded (linear light, video;
+        equal-power, audio) with the next clip's head, and the middle of the clip
+        streams between seams. The held tail carries across the loop, so the
+        stitch spans the clip boundary rather than sitting inside one clip.
+        """
+        xf = self.config.crossfade_frames
+        pending_v: np.ndarray | None = None
+        pending_a: np.ndarray | None = None
+        while self.connected.is_set() and not self._stop_requested:
+            item = await queue.get()
+            if item is None:
+                break
+            index, prompt, video, audio = item
+            n = int(video.shape[0])
+            if pending_v is None:
+                # First clip: stream all but the seam tail, hold the tail.
+                body_end = max(0, n - xf)
+                await self._emit(video[:body_end], audio[:, : body_end * SAMPLES_PER_FRAME])
+                pending_v = video[body_end:].copy()
+                pending_a = audio[:, body_end * SAMPLES_PER_FRAME :].copy()
+            else:
+                # Seam: crossfade the held tail with this clip's head.
+                k = min(xf, n, int(pending_v.shape[0]))
+                if k > 0:
+                    blended_v = seam.blend_video_linear(pending_v[:k], video[:k])
+                    la = min(int(pending_a.shape[-1]), k * SAMPLES_PER_FRAME, int(audio.shape[-1]))
+                    if la > 0:
+                        blended_a = seam.blend_audio_equal_power(
+                            pending_a[:, :la], audio[:, :la]
+                        )
+                    else:
+                        blended_a = np.zeros((1, 0), dtype=np.int16)
+                    await self._emit(blended_v, blended_a)
+                # Middle: this clip minus the blended head and the new held tail.
+                body_end = max(k, n - xf)
+                await self._emit(
+                    video[k:body_end],
+                    audio[:, k * SAMPLES_PER_FRAME : body_end * SAMPLES_PER_FRAME],
+                )
+                pending_v = video[body_end:].copy()
+                pending_a = audio[:, body_end * SAMPLES_PER_FRAME :].copy()
+
+            self._clips_emitted += 1
+            await self.send(
+                ClipComplete(
+                    index=index,
+                    frames=n,
+                    prompt=prompt,
+                    seconds_sent=round(self._seconds_sent, 2),
+                )
+            )
+        # A drained producer (sentinel, not a cut) leaves a tail worth sending.
+        if (
+            pending_v is not None
+            and not self._stop_requested
+            and self.connected.is_set()
+            and pending_v.shape[0] > 0
+        ):
+            await self._emit(pending_v, pending_a)
+
+    # -------------------------------------------------------------- emitter
+
+    async def _emit(self, video: np.ndarray, audio: np.ndarray) -> str:
+        """Emit one video block as paced slices on the chain's 24 fps metronome.
+
+        - Paced by FRAMES, not slices, and by one clock spanning the whole chain,
+          so clip boundaries are gap-free rather than each clip re-anchoring.
+        - Never bursts to catch up: if the transport held a slice back, it
+          re-anchors instead, since a catch-up burst only overflows the queue.
+        - Emits omit ``compute_time``, so every slice is tagged at the pinned
+          24 fps — the rate the audio is already sample-clocked against.
+
+        Returns ``"stopped"`` when `stop`/`reset` cut it, ``"gone"`` when the
+        audience left, ``"done"`` when the whole block went out.
+        """
+        n = int(video.shape[0])
+        if n == 0:
+            return "done"
+        for lo in range(0, n, EMIT_FRAMES):
+            if self._stop_requested:
+                return "stopped"
+            if not self.connected.is_set():
+                return "gone"
+            hi = min(lo + EMIT_FRAMES, n)
+            alo = lo * SAMPLES_PER_FRAME
+            ahi = hi * SAMPLES_PER_FRAME
+
+            now = asyncio.get_running_loop().time()
+            if self._clock_start is None:
+                self._clock_start = now
+            content_pos = self._frames_paced / FRAME_RATE
+            self._clock_start = max(self._clock_start, now - content_pos)
+            delay = self._clock_start + content_pos - now
+            if delay > 0:
+                await asyncio.sleep(delay)
+
+            self._frames_paced += hi - lo
+            self._frames_sent += hi - lo
+            self._seconds_sent = self._frames_sent / FRAME_RATE
+            await self.emit(
+                LiveH3Output(
+                    main_video=np.ascontiguousarray(video[lo:hi]),
+                    main_audio=np.ascontiguousarray(audio[:, alo:ahi]),
+                )
+            )
+        return "done"

--- a/fast-h3-live/live_h3.yaml
+++ b/fast-h3-live/live_h3.yaml
@@ -1,0 +1,109 @@
+# FastH3 live — continuous-chain configuration.
+#
+# `inference` is the generation recipe and the seam knobs; `runtime` is the
+# weight layout and the engine shape. live_h3_assets.py reads this file (the
+# runtime hands over the path and does not parse it). The engine block mirrors
+# `fast-h3/fasth3.yaml` — the same measured VSA/FA4/compile profile — because
+# it is the same checkpoint on the same hardware; only the queue is replaced by
+# the chain (clip length, seam, buffer depth).
+
+inference:
+  # Aspect the session starts at. `set_canvas` can change it while no chain is
+  # running, to any entry in clip_plan.ASPECT_CHOICES. 16:9 resolves to
+  # 1344x768 — the canvas every published FastH3 number was measured at.
+  aspect: "16:9"
+
+  # Length of each clip the chain generates, before the seam overlap.
+  # `set_clip_seconds` changes it for the next chain. 5.167 s is the shortest
+  # the checkpoint generates (124 frames) and the one the validated bear chain
+  # used: short clips seam more often but keep generation furthest ahead of
+  # playback, which is what a continuous stream needs. Raise it to seam less
+  # once a GPU pass confirms the longer clip still builds inside the playout
+  # budget.
+  clip_seconds: 5.167
+
+  # Seam stitch. crossfade_frames is the overlap width the tail of one clip and
+  # the head of the next are blended across — 12 frames (0.5 s) is the width the
+  # linear-light "linearfade" was validated at (monotonic luma, no flash).
+  # color_match `per_clip` shifts every continuation clip by one per-channel
+  # offset onto clip 0's last-frame mean, locked for the whole chain so exposure
+  # cannot ratchet; `off` disables it.
+  crossfade_frames: 12
+  color_match: per_clip
+
+  # How many built clips the producer keeps ahead of the emitter (double
+  # buffering). 2 is enough to cover one clip's build time while the previous
+  # streams; each buffered clip is ~1 GB of uint8 pixels at 768p, so size
+  # resources.memory with it.
+  buffer_depth: 2
+
+  # Seed the chain's first clip generates from; each continuation advances it by
+  # one. `set_seed` overrides for the next chain.
+  seed: 1000
+
+  # Sigma-grid POINTS, not transformer forwards. The distilled schedule is
+  # t=999,749,500,250 -> 0: five points and exactly four forwards. Changing this
+  # leaves the trained schedule and is not supported by the checkpoint.
+  num_inference_steps: 5
+
+  # Video Sparse Attention — the checkpoint's trained and measured policy
+  # (fastvideo_inference.json). The sm100a kernel is built from source at image
+  # build time; sitecustomize.py widens its (10, 0)-only device gate so a B300
+  # (10.3) takes the fast route too. `triton` is the portable, much slower
+  # fallback for a non-Blackwell box.
+  vsa_sparsity: 0.9
+  vsa_tile_size: 64
+  vsa_kernel: sm100a
+
+  # FA4 for the dense (text and audio) attention paths, and the inference-only
+  # H3 fusions. Both are part of the measured profile.
+  fa4: true
+  h3_fusions: true
+
+  # Regional compile of the transformer blocks, and an independently compiled
+  # video VAE decoder. Regional compile is shape-keyed, which is why every clip
+  # length and canvas — and BOTH the T2VA and the FL2VA shape — has to be warmed.
+  inference_torch_compile: true
+  compile_vae: true
+
+  # Sequence-parallel all-to-all route. `off` reproduces the measured profile.
+  ulysses_a2a: "off"
+
+  # Canvases warmed at load, both the T2VA and the FL2VA shape at each. Adding an
+  # entry costs pod-boot time; leaving one out means the first clip at that
+  # canvas pays a one-off compile stall.
+  warmup_aspects: ["16:9"]
+
+  # Clip lengths warmed at load. The live channel generates one length for a
+  # whole chain, so "default" (just clip_seconds) is the right setting — both
+  # the T2VA and FL2VA shape are warmed at it, so neither the first clip nor the
+  # first continuation stalls. Set to "all" only if you expect to change
+  # clip_seconds between chains and want to spare the ~20 s first-use compile.
+  warmup_lengths: "default"
+
+runtime:
+  # Weight bundle layout, relative to the mounted weights root. One HF snapshot
+  # carries every component — transformer, text encoder, both VAEs, both
+  # schedulers, tokenizer and processor. "." means the components sit directly
+  # under the weights root.
+  checkpoint_dir: "."
+
+  # Sequence parallelism spans every GPU (sp_size == num_gpus, tp_size 1).
+  # Eight is what keeps a continuous chain free of build-starved boundaries.
+  # The count must divide H3's 56 attention heads.
+  num_gpus: 8
+
+  # true replicates the transformer on every rank — the configuration
+  # FastVideo's published numbers were measured at, and the fastest denoise.
+  # The resident text encoder below is what leaves the VRAM for it.
+  replicated_dit: true
+
+  # Offload policy. On a dedicated 8-GPU Blackwell pod the resident footprint
+  # fits comfortably in VRAM, so both are off: no per-clip page-in, and the
+  # host stays small. Turn text-encoder offload back on only for shared
+  # machines, together with pin_cpu_memory and a much larger resources.memory.
+  offload_text_encoder: false
+  offload_vae: false
+
+  # Pinned host buffers only matter when the offload above is on; off with it.
+  pin_cpu_memory: false

--- a/fast-h3-live/live_h3_assets.py
+++ b/fast-h3-live/live_h3_assets.py
@@ -1,0 +1,190 @@
+"""Config parsing and weights-bundle validation for the live FastH3 channel.
+
+``live_h3.yaml`` is read here and nowhere else: ``load_config`` turns it into one
+validated :class:`LiveH3Config`, and ``require_weights`` fails startup loudly
+when the bundle on disk is incomplete. Pure file and dict work — no torch, no
+fastvideo — so the schema renders and the tests run on any machine.
+
+This mirrors ``fast-h3/fasth3_assets.py`` but drops the two clip-queue sizes
+(the live channel has no client-facing queue: one held prompt drives an
+open-ended chain) and adds the stream knobs — the seam crossfade width, the
+color-match mode, and how many clips the producer buffers ahead of playout.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+import yaml
+
+import live_h3_clip_plan as clip_plan
+
+# The HF snapshot directory inside the weights bundle — the same checkpoint the
+# hard-cut fast-h3 channel serves.
+DEFAULT_CHECKPOINT_DIR = "FastVideo-FastH3-4-step-Preview-v1-VSA-DataFree"
+
+# Component directories the T2VA/FL2VA pipeline loads. An incomplete bundle must
+# kill startup, not surface as a loader traceback on the first clip.
+REQUIRED_COMPONENTS = (
+    "transformer",
+    "text_encoder",
+    "tokenizer",
+    "processor",
+    "vae",
+    "audio_vae",
+    "scheduler",
+    "audio_scheduler",
+)
+
+
+@dataclass(frozen=True)
+class LiveH3Config:
+    """Everything ``live_h3.yaml`` configures, validated once at load.
+
+    The session-level fields are the defaults a fresh session starts from;
+    ``inference`` and ``runtime`` are the raw blocks the backend reads its engine
+    knobs (attention kernels, compile flags, parallelism, offload policy) from.
+    The stream fields shape the seam: ``crossfade_frames`` is the overlap width,
+    ``color_match`` is ``per_clip`` or ``off``, and ``buffer_depth`` is how many
+    built clips the producer keeps ahead of the emitter.
+    """
+
+    aspect: str
+    clip_frames: int
+    seed: int
+    num_inference_steps: int
+    crossfade_frames: int
+    color_match: str
+    buffer_depth: int
+    warmup_aspects: tuple[str, ...]
+    warmup_frames: tuple[int, ...]
+    inference: dict[str, Any]
+    runtime: dict[str, Any]
+
+
+def load_config(config_path: Path | None) -> LiveH3Config:
+    """Parse ``live_h3.yaml`` into a validated :class:`LiveH3Config`.
+
+    Args:
+        config_path: Path the runtime hands over from ``runtime.config`` in
+            ``reactor.yaml``, or ``None`` when the manifest names no config.
+
+    Raises:
+        ValueError: If the configured aspect is not one this model offers, the
+            crossfade width is negative or not shorter than a clip, the
+            color-match mode is unknown, or the buffer depth is not positive.
+    """
+    document: dict[str, Any] = {}
+    if config_path is not None:
+        document = yaml.safe_load(config_path.read_text(encoding="utf-8")) or {}
+    inference: dict[str, Any] = document.get("inference") or {}
+    runtime: dict[str, Any] = document.get("runtime") or {}
+
+    aspect = str(inference.get("aspect", "16:9"))
+    if aspect not in clip_plan.ASPECT_CHOICES:
+        raise ValueError(
+            f"inference.aspect must be one of {list(clip_plan.ASPECT_CHOICES)}, got {aspect!r}"
+        )
+
+    clip_frames = clip_plan.frames_for_seconds(
+        float(inference.get("clip_seconds", clip_plan.MAX_SECONDS))
+    )
+
+    crossfade_frames = int(inference.get("crossfade_frames", 12))
+    if crossfade_frames < 0:
+        raise ValueError(f"inference.crossfade_frames must be >= 0, got {crossfade_frames}")
+    if crossfade_frames >= clip_frames:
+        raise ValueError(
+            f"inference.crossfade_frames ({crossfade_frames}) must be shorter than a clip "
+            f"({clip_frames} frames)"
+        )
+
+    color_match = str(inference.get("color_match", "per_clip"))
+    if color_match not in ("per_clip", "off"):
+        raise ValueError(f"inference.color_match must be 'per_clip' or 'off', got {color_match!r}")
+
+    buffer_depth = int(inference.get("buffer_depth", 2))
+    if buffer_depth < 1:
+        raise ValueError(f"inference.buffer_depth must be positive, got {buffer_depth}")
+
+    return LiveH3Config(
+        aspect=aspect,
+        clip_frames=clip_frames,
+        seed=int(inference.get("seed", 1000)),
+        # Sigma-grid POINTS, not transformer forwards: the distilled schedule is
+        # five points and exactly four forwards.
+        num_inference_steps=int(inference.get("num_inference_steps", 5)),
+        crossfade_frames=crossfade_frames,
+        color_match=color_match,
+        buffer_depth=buffer_depth,
+        warmup_aspects=tuple(str(a) for a in (inference.get("warmup_aspects") or [aspect])),
+        warmup_frames=_parse_warmup_lengths(inference.get("warmup_lengths"), clip_frames),
+        inference=inference,
+        runtime=runtime,
+    )
+
+
+def _parse_warmup_lengths(raw: Any, clip_frames: int) -> tuple[int, ...]:
+    """Resolve ``inference.warmup_lengths`` to the frame counts load() warms.
+
+    ``"default"`` (or nothing) warms only the session's default length — the
+    right setting for the live channel, whose every clip is that one length;
+    ``"all"`` warms every legal length; a list of seconds warms those, snapped to
+    legal lengths. The default length is always included. Both the T2VA and the
+    FL2VA compile shape are warmed at each of these lengths by the backend.
+    """
+    if raw in (None, "", "default"):
+        return (clip_frames,)
+    if raw == "all":
+        frames = set(clip_plan.legal_frame_counts())
+    elif isinstance(raw, (list, tuple)):
+        frames = {clip_plan.frames_for_seconds(float(seconds)) for seconds in raw}
+    else:
+        raise ValueError(
+            f'inference.warmup_lengths must be "default", "all", or a list of seconds, got {raw!r}'
+        )
+    frames.add(clip_frames)
+    return tuple(sorted(frames))
+
+
+def resolve_model_path(config: LiveH3Config, weights_root: Path) -> Path:
+    """The checkpoint directory inside the mounted weights bundle.
+
+    ``checkpoint_dir: "."`` means the snapshot's components sit directly under
+    the weights root, which is how ``reactor weights upload`` lays a bundle out
+    when the snapshot itself is uploaded.
+    """
+    subdir = str(config.runtime.get("checkpoint_dir", DEFAULT_CHECKPOINT_DIR))
+    if subdir in ("", "."):
+        return weights_root
+    return weights_root / subdir
+
+
+def require_weights(root: Path, model_path: Path) -> None:
+    """Fail startup loudly when the weights bundle is incomplete."""
+    problems: list[str] = []
+    if not model_path.is_dir():
+        problems.append(f"checkpoint directory is missing: {model_path}")
+    else:
+        index = model_path / "modular_model_index.json"
+        if not index.is_file():
+            problems.append(f"modular_model_index.json is missing: {index}")
+        for component in REQUIRED_COMPONENTS:
+            if not (model_path / component).is_dir():
+                problems.append(f"component directory is missing: {model_path / component}")
+    if problems:
+        raise FileNotFoundError(
+            f"FastH3 weights bundle under {root} is incomplete:\n  " + "\n  ".join(problems)
+        )
+
+
+__all__ = [
+    "DEFAULT_CHECKPOINT_DIR",
+    "REQUIRED_COMPONENTS",
+    "LiveH3Config",
+    "load_config",
+    "require_weights",
+    "resolve_model_path",
+]

--- a/fast-h3-live/live_h3_backend.py
+++ b/fast-h3-live/live_h3_backend.py
@@ -1,0 +1,619 @@
+"""The FastVideo engine behind the live channel: GPU work, nothing client-facing.
+
+One :class:`LiveH3Backend` owns the multi-GPU ``VideoGenerator``, the environment
+profile it must be built under, the load-time warm-up, and a single persistent
+worker thread that builds clips one at a time. ``live_h3.py`` submits work with
+:meth:`LiveH3Backend.submit` and polls the returned :class:`ClipJob`.
+
+This is ``fast-h3/fasth3_backend.py`` with one capability added: a build may
+carry an ``anchor_image``, passed to FastVideo as the FL2VA first-frame anchor,
+which is how each continuation clip is conditioned on the previous clip's last
+frame. Everything load-bearing is unchanged — the 256-token prompt pad (a novel
+packed-sequence length would otherwise recompile the transformer at ~23 s a
+clip), the dynamo recompile-limit raise, the profile environment, and the wire
+audio conversion. The FL2VA anchor changes the packed sequence, so it is a
+distinct compile shape: :meth:`_warmup` warms both the T2VA and the FL2VA shape
+at every configured length, or the first continuation clip pays a ~20 s stall.
+
+torch, torchaudio and fastvideo are imported lazily inside methods, so importing
+this module — which rendering the schema does — needs none of them.
+"""
+
+from __future__ import annotations
+
+import os
+import queue
+import threading
+import time
+from pathlib import Path
+from typing import Any
+
+from reactor_runtime.log import get_logger
+
+import live_h3_clip_plan as clip_plan
+from live_h3_assets import LiveH3Config
+
+logger = get_logger(__name__)
+
+FRAME_RATE = clip_plan.FPS
+
+# WebRTC-native rate every clip's waveform is resampled to. The checkpoint's
+# audio decoder is 32 kHz; the wire is 48 kHz.
+OUTPUT_SAMPLE_RATE = 48_000
+NATIVE_SAMPLE_RATE = 32_000
+
+# How often a blocking wait on the worker re-checks. Used only during load().
+_WORKER_POLL_SECONDS = 0.1
+
+# What the warm-up builds. Never reaches a client: warm-up output is discarded,
+# and its only job is to be a syntactically ordinary prompt.
+WARMUP_PROMPT = "A slow cinematic shot of sunlight moving across a quiet room."
+
+# Every prompt is padded (or token-truncated) to exactly this many tokens before
+# it reaches the engine. Regional torch.compile is keyed on the packed sequence
+# length, which includes the prompt's token count, so a novel prompt length would
+# otherwise recompile — measured at ~23 s against ~15 s for the clip itself. One
+# fixed length means one compiled shape, captured by the warm-up and reused by
+# every clip. 256 comfortably holds the 800-character prompt cap.
+PROMPT_TOKENS = 256
+
+
+class ClipJob:
+    """The handle to one submitted build: its inputs, outcome, and completion.
+
+    The error is carried back rather than only logged, so the submitter can
+    report the failed clip. ``cancelled`` set before the worker reaches the job
+    skips the build; set after, the build runs to completion and the submitter
+    discards the result.
+    """
+
+    __slots__ = ("cancelled", "done", "error", "fn", "result")
+
+    def __init__(self, fn) -> None:
+        self.fn = fn
+        self.done = threading.Event()
+        self.error: BaseException | None = None
+        self.result: tuple[list[Any], Any] | None = None
+        self.cancelled = False
+
+
+class LiveH3Backend:
+    """Build FastH3 clips on demand, serialised on one worker thread.
+
+    The GPU work itself lives in the engine processes FastVideo spawns; the
+    thread exists to serialise submissions and to give teardown a single handle
+    to wait on.
+    """
+
+    def __init__(self, config: LiveH3Config, model_path: Path) -> None:
+        """Remember the recipe and the weights location; nothing loads yet."""
+        self._config = config
+        self._model_path = model_path
+        self._jobs: queue.Queue[ClipJob] = queue.Queue()
+        self._worker: threading.Thread | None = None
+        self.generator: Any = None
+
+    # ------------------------------------------------------------------ load
+
+    def load(self) -> None:
+        """Build the generator and warm every T2VA and FL2VA clip shape.
+
+        Runs once at startup. The caller's ``load()`` returning is what marks the
+        pod ready, so everything that can fail — missing kernels, a broken native
+        linkage, a cold compile — must fail here, not on the first client's clip.
+        """
+        # Must happen before the generator is built: the engine spawns worker
+        # processes, which inherit os.environ, and these select the attention
+        # backend and the sparse kernel.
+        self._apply_profile_environment()
+        self._validate_profile_dependencies()
+        self._raise_dynamo_limits()
+
+        runtime = self._config.runtime
+        num_gpus = int(runtime.get("num_gpus", 8))
+        logger.info(
+            "building live fast-h3 generator",
+            model_path=str(self._model_path),
+            num_gpus=num_gpus,
+            clip_frames=self._config.clip_frames,
+        )
+
+        from fastvideo import VideoGenerator
+
+        self.generator = VideoGenerator.from_config(self._generator_config())
+        self._load_tokenizer()
+
+        self._worker = threading.Thread(
+            target=self._worker_loop, name="live-fast-h3-generation", daemon=True
+        )
+        self._worker.start()
+        self._preload_native_imports()
+        self._run_blocking(self._warmup)
+        logger.info("live fast-h3 backend loaded")
+
+    def _load_tokenizer(self) -> None:
+        """Load the bundle's tokenizer and calibrate the one-token pad filler.
+
+        Padding must land on an exact token count, so the filler is verified to
+        cost exactly one token at load rather than assumed.
+        """
+        from transformers import AutoTokenizer
+
+        self._tokenizer = AutoTokenizer.from_pretrained(str(self._model_path / "tokenizer"))
+        for candidate in (" .", ".", " a"):
+            base = len(self._tokenizer.encode(WARMUP_PROMPT, add_special_tokens=False))
+            padded = len(
+                self._tokenizer.encode(WARMUP_PROMPT + candidate, add_special_tokens=False)
+            )
+            if padded == base + 1:
+                self._pad_filler = candidate
+                return
+        raise RuntimeError("no single-token pad filler found for this tokenizer")
+
+    def _pad_prompt(self, prompt: str) -> str:
+        """Return *prompt* at exactly ``PROMPT_TOKENS`` tokens.
+
+        Shorter prompts gain trailing filler tokens; a longer one is truncated at
+        the token boundary. The client-facing prompt is the original; only the
+        engine sees this form.
+        """
+        encode = lambda text: len(self._tokenizer.encode(text, add_special_tokens=False))  # noqa: E731
+        ids = self._tokenizer.encode(prompt, add_special_tokens=False)
+        if ids and len(ids) >= PROMPT_TOKENS:
+            return self._tokenizer.decode(ids[:PROMPT_TOKENS])
+        padded = prompt + self._pad_filler * (PROMPT_TOKENS - len(ids))
+        # Filler cost is calibrated, but a prompt's own tail can merge with the
+        # first filler token; correct by measurement rather than assumption.
+        while encode(padded) > PROMPT_TOKENS:
+            padded = padded[: -len(self._pad_filler)]
+        while encode(padded) < PROMPT_TOKENS:
+            padded += self._pad_filler
+        if encode(padded) != PROMPT_TOKENS:
+            logger.warning(f"prompt padded to {encode(padded)} tokens, not {PROMPT_TOKENS}")
+        return padded
+
+    @staticmethod
+    def _raise_dynamo_limits() -> None:
+        """Raise torch dynamo's recompile limits in this (parent) process.
+
+        Every distinct clip shape is a compile shape, and the fullgraph
+        regional-compile route treats exceeding the limit as a hard failure. This
+        covers the parent; the engine *workers* are spawned interpreters that
+        FastVideo's own imports re-cap at 16, which is what the
+        ``sitecustomize.py`` shipped next to this file fixes — the manifest puts
+        it on ``PYTHONPATH`` so every process in the container loads it. The two
+        share the ``FASTH3_DYNAMO_RECOMPILE_LIMIT`` knob (default 64).
+        """
+        import torch._dynamo.config as dynamo_config
+
+        limit = int(os.environ.get("FASTH3_DYNAMO_RECOMPILE_LIMIT", "64"))
+        dynamo_config.recompile_limit = max(limit, dynamo_config.recompile_limit)
+        dynamo_config.cache_size_limit = max(limit, dynamo_config.cache_size_limit)
+        dynamo_config.accumulated_recompile_limit = max(
+            512, dynamo_config.accumulated_recompile_limit
+        )
+        dynamo_config.accumulated_cache_size_limit = max(
+            512, dynamo_config.accumulated_cache_size_limit
+        )
+        dynamo_config.fail_on_recompile_limit_hit = False
+        logger.info(
+            "dynamo recompile limits raised",
+            recompile_limit=dynamo_config.recompile_limit,
+            in_workers="via /app/sitecustomize.py on PYTHONPATH",
+        )
+
+    @staticmethod
+    def _preload_native_imports() -> None:
+        """Touch every deferred native import the build path needs.
+
+        Lazy imports mean the first import would otherwise happen on the first
+        real clip — after load, after warm-up, after the pod reports ready —
+        where a linkage failure is a dead session rather than a startup error.
+        The resample below is a real call, so it fails here or not at all.
+        """
+        import numpy  # noqa: F401
+        import torch
+        import torchaudio.functional as AF
+
+        AF.resample(torch.zeros(2, NATIVE_SAMPLE_RATE // 10), NATIVE_SAMPLE_RATE, OUTPUT_SAMPLE_RATE)
+
+    # --------------------------------------------------------------- profile
+
+    def _apply_profile_environment(self) -> None:
+        """Set the FastH3 profile environment, exactly as the reference CLI does.
+
+        Mirrors ``examples/inference/basic/basic_fasth3.py:profile_environment``.
+        Values are explicit even for disabled features, so a shell's inherited
+        experiment settings cannot silently change the profile a pod serves.
+        """
+        cfg = self._config.inference
+        vsa_kernel = str(cfg.get("vsa_kernel", "sm100a"))
+        fusions = "all" if bool(cfg.get("h3_fusions", True)) else "0"
+        environment: dict[str, str | None] = {
+            "FASTVIDEO_ATTENTION_BACKEND": "VIDEO_SPARSE_ATTN_H3",
+            "FASTVIDEO_VSA_SM100A": "1" if vsa_kernel == "sm100a" else "0",
+            "FASTVIDEO_VSA_CUTEDSL": "0",
+            # A non-empty path enables the diagnostic probe; it must stay unset.
+            "FASTVIDEO_H3_VSA_PROBE": None,
+            "FASTVIDEO_DISABLE_ATTENTION_COMPILE": "0",
+            "FASTVIDEO_FA4": "1" if bool(cfg.get("fa4", True)) else "0",
+            "FASTVIDEO_NVFP4_FA4": "0",
+            "FASTVIDEO_MINIMAX_H3_FA4_PACKED_VARLEN": "0",
+            "FASTVIDEO_MINIMAX_H3_FUSIONS": fusions,
+            "FASTVIDEO_INFERENCE_TORCH_COMPILE": (
+                "1" if bool(cfg.get("inference_torch_compile", True)) else "0"
+            ),
+            "FASTVIDEO_VAE_PARALLEL_DECODE": (
+                "1" if bool(cfg.get("vae_parallel_decode", True)) else "0"
+            ),
+            "FASTVIDEO_VAE_PARALLEL_ENCODE": "0",
+            "FASTVIDEO_VAE_PARALLEL_DECODE_STRATEGY": "gather",
+            "FASTVIDEO_ULYSSES_A2A": str(cfg.get("ulysses_a2a", "off")),
+            "FASTVIDEO_STAGE_LOGGING": "1",
+        }
+        for name, value in environment.items():
+            if value is None:
+                os.environ.pop(name, None)
+            else:
+                os.environ[name] = value
+        logger.info("live fast-h3 profile", **{k: (v or "<unset>") for k, v in environment.items()})
+
+    def _validate_profile_dependencies(self) -> None:
+        """Fail before the 148 GB load when the selected fast route is absent."""
+        import importlib.util
+
+        cfg = self._config.inference
+        if bool(cfg.get("fa4", True)):
+            try:
+                present = importlib.util.find_spec("flash_attn.cute") is not None
+            except (ImportError, ModuleNotFoundError):
+                present = False
+            if not present:
+                raise RuntimeError(
+                    "FastH3's FA4 route needs the pinned flash-attn-4 package. Install it, "
+                    "or set inference.fa4: false in live_h3.yaml."
+                )
+        if str(cfg.get("vsa_kernel", "sm100a")) == "sm100a":
+            try:
+                from fastvideo_kernel import block_sparse_attn_sm100a
+            except ImportError:
+                present = False
+            else:
+                present = bool(getattr(block_sparse_attn_sm100a, "_HAS_VSA_SM100A", False))
+            if not present:
+                raise RuntimeError(
+                    "FastH3's sm100a route needs fastvideo-kernel built with the Blackwell VSA "
+                    "extension. Install a matching wheel, or set inference.vsa_kernel: triton."
+                )
+
+    def _generator_config(self):
+        """The engine shape, mirroring ``basic_fasth3.py:build_generator_config``."""
+        from fastvideo.api import (
+            CompileConfig,
+            ComponentConfig,
+            EngineConfig,
+            GeneratorConfig,
+            OffloadConfig,
+            ParallelismConfig,
+            PipelineSelection,
+        )
+
+        cfg = self._config.inference
+        runtime = self._config.runtime
+        num_gpus = int(runtime.get("num_gpus", 8))
+        # The checkpoint's own contract (fastvideo_inference.json) shards the
+        # transformer with FSDP. Sharding is what frees the VRAM to keep the
+        # text encoder resident, which is the deployment this model wants.
+        replicated_dit = bool(runtime.get("replicated_dit", False))
+        return GeneratorConfig(
+            model_path=str(self._model_path),
+            pipeline=PipelineSelection(
+                components=ComponentConfig(),
+                experimental={
+                    "attention_backend": "VIDEO_SPARSE_ATTN_H3",
+                    "VSA_sparsity": float(cfg.get("vsa_sparsity", 0.9)),
+                    "VSA_tile_size": int(cfg.get("vsa_tile_size", 64)),
+                    "inference_torch_compile": bool(cfg.get("inference_torch_compile", True)),
+                    "vae_parallel_decode": bool(cfg.get("vae_parallel_decode", True)),
+                    "vae_parallel_decode_strategy": "gather",
+                },
+            ),
+            engine=EngineConfig(
+                num_gpus=num_gpus,
+                use_fsdp_inference=num_gpus > 1 and not replicated_dit,
+                parallelism=ParallelismConfig(tp_size=1, sp_size=num_gpus),
+                offload=OffloadConfig(
+                    dit=False,
+                    dit_layerwise=False,
+                    text_encoder=bool(runtime.get("offload_text_encoder", False)),
+                    vae=bool(runtime.get("offload_vae", False)),
+                    pin_cpu_memory=bool(runtime.get("pin_cpu_memory", False)),
+                ),
+                compile=CompileConfig(
+                    enabled=False,
+                    mode=None,
+                    vae_enabled=bool(cfg.get("compile_vae", True)),
+                ),
+            ),
+        )
+
+    # ---------------------------------------------------------------- worker
+
+    def _worker_loop(self) -> None:
+        """Run submitted jobs, one at a time, forever.
+
+        The waiter is always released, even when the job died: a completion event
+        that never arrives is indistinguishable from a hang, and this thread is
+        the only one that will ever set it.
+        """
+        logger.info("generation worker ready")
+        while True:
+            job = self._jobs.get()
+            try:
+                if not job.cancelled:
+                    job.result = job.fn()
+            except BaseException as error:  # noqa: BLE001 — handed to the submitter
+                job.error = error
+                logger.exception("generation worker job raised")
+            finally:
+                job.done.set()
+
+    def submit(
+        self,
+        *,
+        frames: int,
+        prompt: str,
+        seed: int,
+        height: int,
+        width: int,
+        anchor_image: Any = None,
+    ) -> ClipJob:
+        """Queue one clip build and hand back its job handle.
+
+        Returns immediately; the caller polls ``job.done`` and reads
+        ``job.result`` — ``(frames_list, samples)``, RGB uint8 frames and an
+        int16 ``[1, samples]`` waveform at the wire rate — or ``job.error``. When
+        ``anchor_image`` is a PIL image it is the FL2VA first-frame anchor; None
+        is a plain T2VA build (the chain's first clip).
+        """
+        job = ClipJob(
+            lambda: self._generate_clip(
+                frames=frames,
+                prompt=prompt,
+                seed=seed,
+                height=height,
+                width=width,
+                anchor_image=anchor_image,
+            )
+        )
+        self._jobs.put(job)
+        return job
+
+    def _run_blocking(self, fn) -> None:
+        """Run work on the worker, block until it finishes, and re-raise its failure.
+
+        Used only by ``load()``. Blocking here is the point: the runtime marks the
+        pod ready when the model's ``load()`` returns, so a failed warm-up has to
+        stop startup rather than being discovered by the first client.
+        """
+        job = ClipJob(fn)
+        self._jobs.put(job)
+        while not job.done.wait(timeout=_WORKER_POLL_SECONDS):
+            pass
+        if job.error is not None:
+            raise job.error
+
+    # --------------------------------------------------------------- warm-up
+
+    @staticmethod
+    def _gray_anchor(height: int, width: int):
+        """A neutral FL2VA anchor for warm-up: content is discarded, shape is not."""
+        from PIL import Image
+
+        return Image.new("RGB", (width, height), (128, 128, 128))
+
+    def _warmup(self) -> None:
+        """Build one throwaway clip per shape, T2VA and FL2VA, before ready.
+
+        Every distinct frame count and canvas is a separate one-time cost, and
+        the FL2VA path adds keyframe rows to the packed sequence — a distinct
+        compile shape from T2VA at the same length. The chain's first clip is
+        T2VA and every continuation is FL2VA, so both are warmed at each length,
+        or the first continuation clip pays a ~20 s regional-compile stall live.
+        Results are discarded: ``return_frames=False`` skips the post-decode path.
+        """
+        aspects = self._config.warmup_aspects
+        cold = [a for a in clip_plan.ASPECT_CHOICES if a not in aspects]
+        if cold:
+            logger.info(
+                "aspects left cold; their first clip pays a one-off compile stall", aspects=cold
+            )
+        shapes: list[tuple[str, int]] = [
+            (aspect, self._config.clip_frames) for aspect in aspects
+        ]
+        shapes += [
+            (aspects[0], frames)
+            for frames in self._config.warmup_frames
+            if frames != self._config.clip_frames
+        ]
+        logger.info(
+            "warm-up plan",
+            shapes=len(shapes),
+            paths=["t2va", "fl2va"],
+            lengths=[round(clip_plan.seconds_for_frames(f), 3) for f in self._config.warmup_frames],
+        )
+        total = len(shapes) * 2
+        index = 0
+        for aspect, frames in shapes:
+            height, width = clip_plan.canvas_for_choice(aspect)
+            for path, anchor in (("t2va", None), ("fl2va", self._gray_anchor(height, width))):
+                index += 1
+                started = time.monotonic()
+                self.generator.generate(
+                    self._request(
+                        frames=frames,
+                        prompt=WARMUP_PROMPT,
+                        seed=self._config.seed,
+                        height=height,
+                        width=width,
+                        keep_output=False,
+                        anchor_image=anchor,
+                    )
+                )
+                logger.info(
+                    "warmed clip shape",
+                    progress=f"{index}/{total}",
+                    path=path,
+                    aspect=aspect,
+                    frames=frames,
+                    height=height,
+                    width=width,
+                    seconds=round(time.monotonic() - started, 2),
+                )
+
+    # ------------------------------------------------------------ generation
+
+    def _request(
+        self,
+        *,
+        frames: int,
+        prompt: str,
+        seed: int,
+        height: int,
+        width: int,
+        keep_output: bool,
+        anchor_image: Any = None,
+    ):
+        """Build one generation request.
+
+        Mirrors ``basic_fasth3.py:build_request``. ``keep_output=False`` is the
+        warm-up shape: it skips the whole post-decode path. ``anchor_image``, when
+        set, is passed as the FL2VA first-frame anchor.
+        """
+        from fastvideo.api import GenerationRequest, OutputConfig, SamplingConfig
+
+        try:
+            from fastvideo.api import InputConfig
+        except Exception:  # pragma: no cover - fallback for layout drift
+            from fastvideo.api.schema import InputConfig  # type: ignore
+
+        inputs = InputConfig(pil_image=anchor_image) if anchor_image is not None else InputConfig()
+        return GenerationRequest(
+            # Padded to the fixed token length so one compiled shape serves every
+            # prompt; the client-facing prompt keeps the original text.
+            prompt=self._pad_prompt(prompt),
+            # MiniMax-H3 is guidance-distilled, so there is no negative branch to
+            # steer and no CFG pass to pay for.
+            negative_prompt="",
+            sampling=SamplingConfig(
+                height=height,
+                width=width,
+                num_frames=frames,
+                fps=FRAME_RATE,
+                num_inference_steps=self._config.num_inference_steps,
+                guidance_scale=1.0,
+                batch_cfg=False,
+                seed=seed,
+            ),
+            inputs=inputs,
+            output=OutputConfig(save_video=False, return_frames=keep_output),
+        )
+
+    def _generate_clip(
+        self, *, frames: int, prompt: str, seed: int, height: int, width: int, anchor_image: Any
+    ):
+        """Build one clip and convert it to what the output tracks want.
+
+        Returns ``(frames_list, samples)``: a list of RGB uint8 ``[h, w, 3]``
+        arrays and int16 ``[1, samples]`` at 48 kHz, trimmed to exactly
+        ``len(frames_list) / 24`` seconds so the two tracks stay in lockstep. The
+        caller reads ``frames_list[-1]`` as the next clip's FL2VA anchor.
+        """
+        started = time.monotonic()
+        result = self.generator.generate(
+            self._request(
+                frames=frames,
+                prompt=prompt,
+                seed=seed,
+                height=height,
+                width=width,
+                keep_output=True,
+                anchor_image=anchor_image,
+            )
+        )
+        built = time.monotonic() - started
+
+        frames_list = result.frames
+        if not frames_list:
+            raise RuntimeError("the generator returned no frames")
+        samples = self._to_wire_audio(result.audio, result.audio_sample_rate, len(frames_list))
+        # The line to evaluate the deployment by: build seconds against content
+        # seconds (realtime_x > 1 means the clip built faster than it plays) on
+        # the GPU count that produced it, with the per-stage split.
+        content = len(frames_list) / FRAME_RATE
+        gpus = int(self._config.runtime.get("num_gpus", 8))
+        path = "fl2va" if anchor_image is not None else "t2va"
+        logger.info(
+            f"clip built ({path}): {len(frames_list)}f ({content:.2f}s content) in {built:.2f}s "
+            f"= {content / built:.2f}x realtime on {gpus} gpus, "
+            f"stages={self._stage_times(result)}"
+        )
+        return frames_list, samples
+
+    @staticmethod
+    def _stage_times(result) -> dict:
+        """Per-stage seconds from the generator, for the clip log line."""
+        try:
+            stages = getattr(getattr(result, "logging_info", None), "stages", None)
+            if not stages:
+                return {}
+            return {
+                name: round(float(metrics["execution_time"]), 3)
+                for name, metrics in stages.items()
+                if metrics.get("execution_time") is not None
+            }
+        except Exception:  # noqa: BLE001 — a log line must never fail a clip
+            logger.exception("could not read the generator stage timings")
+            return {}
+
+    def _to_wire_audio(self, audio, sample_rate, frames: int):
+        """Resample, downmix and quantize one clip's waveform for the wire.
+
+        Mono at the source is deliberate: the transport mean-downmixes before the
+        wire anyway, and the runtime recorder flattens two channels by
+        concatenation, so a stereo emit only corrupts recordings. Averaging here,
+        in float and before the int16 scale, is the same downmix one step
+        earlier.
+        """
+        import torch
+        import torchaudio.functional as AF
+
+        if audio is None:
+            raise RuntimeError("the generator returned no audio")
+        waveform = audio if torch.is_tensor(audio) else torch.as_tensor(audio)
+        waveform = waveform.detach().float().cpu()
+        # The decoder hands back [samples, channels]; the wire wants channel-major.
+        if waveform.ndim == 1:
+            waveform = waveform.unsqueeze(0)
+        elif waveform.shape[0] > waveform.shape[1]:
+            waveform = waveform.transpose(0, 1)
+        waveform = waveform.contiguous()
+
+        rate = int(sample_rate or NATIVE_SAMPLE_RATE)
+        if rate != OUTPUT_SAMPLE_RATE:
+            waveform = AF.resample(waveform, rate, OUTPUT_SAMPLE_RATE)
+        if waveform.shape[0] > 1:
+            waveform = waveform.mean(dim=0, keepdim=True)
+
+        want = round(frames / FRAME_RATE * OUTPUT_SAMPLE_RATE)
+        if waveform.shape[-1] > want:
+            waveform = waveform[:, :want]
+        elif waveform.shape[-1] < want:
+            pad = torch.zeros(
+                (waveform.shape[0], want - waveform.shape[-1]), dtype=waveform.dtype
+            )
+            waveform = torch.cat([waveform, pad], dim=-1)
+        return (waveform.clamp(-1, 1) * 32767).to(torch.int16).numpy()
+
+
+__all__ = ["OUTPUT_SAMPLE_RATE", "NATIVE_SAMPLE_RATE", "ClipJob", "LiveH3Backend"]

--- a/fast-h3-live/live_h3_clip_plan.py
+++ b/fast-h3-live/live_h3_clip_plan.py
@@ -1,0 +1,163 @@
+"""Clip geometry for the FastH3 channel.
+
+Pure arithmetic over the checkpoint's published constraints: how long a clip may
+be, how many frames that is, and what canvas an aspect ratio resolves to. No
+torch, no fastvideo, no GPU — so ``python -m reactor_runtime.schema`` and the
+structural tests import it on any machine.
+
+The constants below are duplicated from FastVideo rather than imported, because
+importing ``fastvideo.pipelines.basic.minimax_h3.packing`` drags in torch.
+``tests/test_fasth3.py`` asserts they still match upstream whenever fastvideo
+is importable, so the duplication cannot drift silently.
+"""
+
+from __future__ import annotations
+
+import math
+
+FPS = 24
+"""The only frame rate MiniMax-H3 accepts; the pipeline rejects anything else."""
+
+# The causal VAE consumes video in 17-frame chunks that decode to 5 latents, so
+# a valid pixel length is always `17n + 5`.
+_FRAMES_PER_CHUNK = 17
+_LATENTS_PER_CHUNK = 5
+
+# The checkpoint's trained duration window, in seconds.
+_MIN_DURATION = 5.0
+_MAX_DURATION = 15.0
+
+# Canvas rules: the short edge is fixed, total area is capped, and both sides
+# must land on a multiple of 32.
+_SHORT_EDGE = 768
+_MAX_PIXELS = 768 * 1344
+_CANVAS_MULTIPLE = 32
+_MIN_ASPECT = 1 / 4
+_MAX_ASPECT = 4
+
+
+def align_frames(frames: int) -> int:
+    """Round up to the next valid `17n + 5` pixel length."""
+    if frames < 1:
+        raise ValueError(f"frames must be positive, got {frames}")
+    while frames % _FRAMES_PER_CHUNK != _LATENTS_PER_CHUNK:
+        frames += 1
+    return frames
+
+
+def _bounds() -> tuple[int, int]:
+    """The shortest and longest clip that satisfies both alignment and duration.
+
+    The ceiling is the subtle one: 15.0 s is 360 frames, which aligns *up* to
+    362 (15.083 s) and is then rejected for exceeding the duration cap. So the
+    longest clip this checkpoint will actually generate is 345 frames.
+    """
+    low = align_frames(int(_MIN_DURATION * FPS))
+    high = low
+    while True:
+        nxt = align_frames(high + 1)
+        if nxt / FPS > _MAX_DURATION:
+            return low, high
+        high = nxt
+
+
+MIN_FRAMES, MAX_FRAMES = _bounds()
+MIN_SECONDS = MIN_FRAMES / FPS
+MAX_SECONDS = MAX_FRAMES / FPS
+
+# The same bounds as the schema publishes them. Rounded *inward* to three
+# decimals so a client reads "5.167", not "5.166666666666667", and so every
+# value inside the published range still snaps to a generatable clip.
+MIN_SECONDS_PUBLISHED = math.ceil(MIN_SECONDS * 1000) / 1000
+MAX_SECONDS_PUBLISHED = math.floor(MAX_SECONDS * 1000) / 1000
+
+
+def legal_frame_counts() -> tuple[int, ...]:
+    """Every clip length this checkpoint can generate, in frames, ascending.
+
+    The `17n + 5` alignment makes consecutive legal lengths exactly one chunk
+    (17 frames) apart, so the whole space is a simple range.
+    """
+    return tuple(range(MIN_FRAMES, MAX_FRAMES + 1, _FRAMES_PER_CHUNK))
+
+
+def frames_for_seconds(seconds: float) -> int:
+    """Snap a requested clip length to the nearest length the model can make.
+
+    Rounds up to a valid frame count, then clamps into the generatable range, so
+    every accepted value round-trips through ``seconds_for_frames``.
+    """
+    if seconds <= 0:
+        raise ValueError(f"seconds must be positive, got {seconds}")
+    frames = align_frames(max(1, round(seconds * FPS)))
+    return max(MIN_FRAMES, min(MAX_FRAMES, frames))
+
+
+def seconds_for_frames(frames: int) -> float:
+    """Exact playout length of a clip, in seconds."""
+    return frames / FPS
+
+
+def canvas_for_aspect(aspect_width: float, aspect_height: float) -> tuple[int, int]:
+    """Resolve an aspect ratio to a `(height, width)` the checkpoint accepts.
+
+    Mirrors FastVideo's ``resolve_canvas_size``: pin the short edge to 768,
+    shrink to the area cap if the result is too wide, then round both sides to a
+    multiple of 32.
+    """
+    if aspect_width <= 0 or aspect_height <= 0:
+        raise ValueError(f"aspect must be positive, got {aspect_width}:{aspect_height}")
+    ratio = aspect_width / aspect_height
+    if not _MIN_ASPECT <= ratio <= _MAX_ASPECT:
+        raise ValueError(f"aspect ratios run from 1:4 to 4:1, got {aspect_width}:{aspect_height}")
+
+    if ratio >= 1:
+        width, height = _SHORT_EDGE * ratio, float(_SHORT_EDGE)
+    else:
+        width, height = float(_SHORT_EDGE), _SHORT_EDGE / ratio
+    area = width * height
+    if area > _MAX_PIXELS:
+        scale = (_MAX_PIXELS / area) ** 0.5
+        width, height = width * scale, height * scale
+    m = _CANVAS_MULTIPLE
+    return max(m, round(height / m) * m), max(m, round(width / m) * m)
+
+
+# The canvases `set_canvas` offers. Deliberately a short list: every entry is a
+# distinct tensor shape that load() must warm, and an unwarmed shape pays a
+# one-off compile stall on its first clip.
+ASPECT_CHOICES: tuple[str, ...] = ("16:9", "1:1", "9:16", "4:3")
+
+_ASPECT_RATIOS: dict[str, tuple[int, int]] = {
+    "16:9": (16, 9),
+    "1:1": (1, 1),
+    "9:16": (9, 16),
+    "4:3": (4, 3),
+}
+
+
+def canvas_for_choice(aspect: str) -> tuple[int, int]:
+    """Resolve one of ``ASPECT_CHOICES`` to `(height, width)`."""
+    try:
+        ratio = _ASPECT_RATIOS[aspect]
+    except KeyError:
+        raise ValueError(f"unknown aspect {aspect!r}; choose one of {list(ASPECT_CHOICES)}") from None
+    return canvas_for_aspect(*ratio)
+
+
+__all__ = [
+    "ASPECT_CHOICES",
+    "FPS",
+    "MAX_FRAMES",
+    "MAX_SECONDS",
+    "MAX_SECONDS_PUBLISHED",
+    "MIN_FRAMES",
+    "MIN_SECONDS",
+    "MIN_SECONDS_PUBLISHED",
+    "align_frames",
+    "canvas_for_aspect",
+    "canvas_for_choice",
+    "frames_for_seconds",
+    "legal_frame_counts",
+    "seconds_for_frames",
+]

--- a/fast-h3-live/live_h3_seam.py
+++ b/fast-h3-live/live_h3_seam.py
@@ -1,0 +1,141 @@
+"""Seam stitching for the continuous FL2VA chain — pure numpy, no torch, no GPU.
+
+The live channel chains clips: clip N+1 is generated with FL2VA anchored on clip
+N's last frame, so consecutive clips already share a near-identical boundary
+frame. Two operations turn a sequence of such clips into one continuous stream,
+and both live here so they can be tested on any machine:
+
+* :func:`color_match_to_reference` — locks every continuation clip's mean RGB to
+  a single reference (clip 0's last frame). Per-clip (one offset for the whole
+  clip), so intra-clip variation is untouched; anchored to clip 0 rather than the
+  running clip, so exposure cannot ratchet across a long chain.
+
+* :func:`blend_video_linear` — the "linearfade" seam: a crossfade done in
+  **linear light** with **complementary weights** (``w_out + w_in == 1``) plus a
+  ramped local exposure match. Blending in sRGB with equal-power weights
+  overshoots at the midpoint for the near-identical frames FL2VA produces — a
+  visible brightness *flash*. Linear light with complementary weights removes the
+  overshoot; the exposure offset, full at the overlap's start and ramped to zero
+  by its end, keeps the dissolve monotonic with no blend-end pop.
+
+Audio crossfades with equal-power (constant-energy) ramps, which is correct for
+the decorrelated waveforms at a seam (unlike the correlated video frames).
+"""
+
+from __future__ import annotations
+
+import numpy as np
+
+__all__ = [
+    "srgb_to_linear",
+    "linear_to_srgb",
+    "luma",
+    "color_match_to_reference",
+    "reference_rgb",
+    "blend_video_linear",
+    "equal_power_ramps",
+    "blend_audio_equal_power",
+]
+
+
+def srgb_to_linear(s: np.ndarray) -> np.ndarray:
+    """sRGB in [0,1] to linear light. The standard piecewise transfer curve."""
+    s = np.clip(s, 0.0, 1.0)
+    return np.where(s <= 0.04045, s / 12.92, ((s + 0.055) / 1.055) ** 2.4)
+
+
+def linear_to_srgb(l: np.ndarray) -> np.ndarray:
+    """Linear light to sRGB in [0,1]. Inverse of :func:`srgb_to_linear`."""
+    l = np.clip(l, 0.0, 1.0)
+    return np.where(l <= 0.0031308, l * 12.92, 1.055 * (l ** (1.0 / 2.4)) - 0.055)
+
+
+def luma(frames_u8: np.ndarray) -> np.ndarray:
+    """Rec.709 luma per frame, mean over pixels, from uint8 RGB ``(N,H,W,3)``."""
+    f = frames_u8.astype(np.float32)
+    y = 0.2126 * f[..., 0] + 0.7152 * f[..., 1] + 0.0722 * f[..., 2]
+    return y.reshape(y.shape[0], -1).mean(axis=1)
+
+
+def reference_rgb(frame_u8: np.ndarray) -> np.ndarray:
+    """The per-channel mean RGB of one frame — the color-match reference.
+
+    Locked once to clip 0's last frame and held constant for the whole chain, so
+    exposure stays anchored instead of ratcheting.
+    """
+    return frame_u8.reshape(-1, 3).mean(axis=0).astype(np.float32)
+
+
+def color_match_to_reference(frames_u8: np.ndarray, target_rgb: np.ndarray) -> np.ndarray:
+    """Shift a whole clip by ONE per-channel offset so its mean RGB is ``target_rgb``.
+
+    A single offset for every frame — not per-frame — so the clip keeps its
+    natural intra-clip luminance and color variation while its average is pinned
+    to the reference. ``target_rgb`` is clip 0's last-frame mean, constant across
+    the chain, which is what stops exposure drift from compounding.
+    """
+    f = frames_u8.astype(np.float32)
+    src = f.reshape(-1, 3).mean(axis=0)
+    f += (target_rgb - src).astype(np.float32)[None, None, None, :]
+    return np.clip(f, 0.0, 255.0).astype(np.uint8)
+
+
+def blend_video_linear(
+    tail_u8: np.ndarray, head_u8: np.ndarray, *, exposure_match: bool = True
+) -> np.ndarray:
+    """Linear-light crossfade of a clip's tail with the next clip's head.
+
+    ``tail_u8`` and ``head_u8`` are the ``(k,H,W,3)`` overlap frames — the last
+    ``k`` of clip N and the first ``k`` of clip N+1. The dissolve runs the head
+    weight from 0 to 1 across the window with complementary weights (``w_out =
+    1 - w_in``) in linear light, so there is no midpoint brightness bump.
+
+    ``exposure_match`` adds a per-frame, per-channel offset that pulls the head
+    onto the tail's mean level at the overlap's start and **ramps to zero** by
+    its end, so the head arrives at its own true level exactly as the body
+    resumes — a constant pin would darken the blend then pop when the body takes
+    over. Returns ``(k,H,W,3)`` uint8.
+    """
+    k = int(tail_u8.shape[0])
+    if k == 0:
+        return tail_u8[:0]
+    lt = srgb_to_linear(tail_u8.astype(np.float32) / 255.0)
+    lh = srgb_to_linear(head_u8.astype(np.float32) / 255.0)
+    if exposure_match:
+        mt = lt.reshape(k, -1, 3).mean(axis=1)
+        mh = lh.reshape(k, -1, 3).mean(axis=1)
+        wr = ((np.arange(k, dtype=np.float32) + 0.5) / k)[:, None]
+        offset = (mt - mh) * (1.0 - wr)  # full at start, zero by the end
+        lh = np.clip(lh + offset[:, None, None, :], 0.0, 1.0)
+    w_in = ((np.arange(k, dtype=np.float32) + 0.5) / k)[:, None, None, None]
+    blended_linear = lt * (1.0 - w_in) + lh * w_in
+    return (np.clip(linear_to_srgb(blended_linear), 0.0, 1.0) * 255.0).round().astype(np.uint8)
+
+
+def equal_power_ramps(n: int) -> tuple[np.ndarray, np.ndarray]:
+    """Equal-power (constant-energy) fade-out/fade-in ramps of length ``n``.
+
+    ``fade_out**2 + fade_in**2 == 1``, the correct crossfade for the decorrelated
+    waveforms at an audio seam — it holds perceived loudness flat where a linear
+    fade would dip.
+    """
+    if n <= 0:
+        return np.ones(0, np.float32), np.ones(0, np.float32)
+    t = (np.arange(n, dtype=np.float32) + 0.5) / n
+    return np.cos(t * (np.pi / 2.0)).astype(np.float32), np.sin(t * (np.pi / 2.0)).astype(np.float32)
+
+
+def blend_audio_equal_power(tail_i16: np.ndarray, head_i16: np.ndarray) -> np.ndarray:
+    """Equal-power overlap-add of two int16 mono waveforms ``(1,S)`` of equal length.
+
+    Blends in float to avoid int16 wrap at the sum, then requantizes. Returns
+    ``(1,S)`` int16.
+    """
+    s = int(min(tail_i16.shape[-1], head_i16.shape[-1]))
+    if s == 0:
+        return np.zeros((1, 0), dtype=np.int16)
+    fade_out, fade_in = equal_power_ramps(s)
+    tail = tail_i16[:, :s].astype(np.float32)
+    head = head_i16[:, :s].astype(np.float32)
+    mixed = tail * fade_out[None, :] + head * fade_in[None, :]
+    return np.clip(mixed, -32768.0, 32767.0).astype(np.int16)

--- a/fast-h3-live/live_h3_types.py
+++ b/fast-h3-live/live_h3_types.py
@@ -1,0 +1,190 @@
+"""Client-facing types for the live (continuous-chain) FastH3 model.
+
+Everything a client can see lives here: the outbound video and audio tracks and
+the typed messages the model sends. ``live_h3.py`` imports these; a frontend
+developer reads this file to learn the whole API without opening the inference
+code.
+
+Unlike the hard-cut ``fast-h3`` channel, this model has no queue and no
+per-clip identity a client addresses. One held prompt drives an open-ended
+chain: ``start`` begins it, each generated clip is stitched onto the last and
+streamed continuously, and ``stop`` ends it. So the messages here describe the
+*stream*, not clips-as-objects — ``clip_complete`` is progress, not a handle.
+
+The conditions behind the ``set_*`` commands are not here. A ``ReactorModel``
+owns its session state itself, so they are plain attributes on ``LiveH3`` reset
+in ``_reset_session_state``; their client-facing text lives on each handler's
+own ``InputField`` declaration.
+"""
+
+from __future__ import annotations
+
+from reactor_runtime import (
+    Audio,
+    MessageField,
+    ModelMessage,
+    Output,
+    Video,
+)
+
+MAX_PROMPT_CHARS = 800
+
+
+class LiveH3Output(Output):
+    """The generated video and its synchronized audio, streamed continuously."""
+
+    main_video: Video
+    main_audio: Audio
+
+
+class StateUpdate(ModelMessage):
+    """Emitted on connect and after every change to the session's state.
+
+    One snapshot of everything observable, so a client can render its whole UI
+    from this alone instead of accumulating the individual messages below.
+    """
+
+    prompt: str = MessageField(
+        description=(
+            "The held prompt the chain generates from. Empty until `set_prompt`; "
+            "`start` needs it non-empty."
+        )
+    )
+    streaming: bool = MessageField(
+        description="A continuous chain is generating and playing on the output tracks."
+    )
+    clip_seconds: float = MessageField(
+        description="Length of each clip the chain generates, before seam overlap."
+    )
+    clip_seconds_min: float = MessageField(
+        description="Shortest clip length `set_clip_seconds` accepts."
+    )
+    clip_seconds_max: float = MessageField(
+        description="Longest clip length `set_clip_seconds` accepts."
+    )
+    seed: int = MessageField(
+        description=(
+            "Seed the chain's first clip generates from; each continuation clip "
+            "advances it by one so a run is reproducible."
+        )
+    )
+    aspect: str = MessageField(description="Aspect ratio in effect, e.g. `16:9`.")
+    width: int = MessageField(description="Width of every frame on `main_video`.")
+    height: int = MessageField(description="Height of every frame on `main_video`.")
+    clips_emitted: int = MessageField(
+        description="Clips stitched into the stream since it started."
+    )
+    seconds_sent: float = MessageField(
+        description="Seconds of video and audio sent since the stream started."
+    )
+    valid_commands: list[str] = MessageField(
+        description=(
+            "Names of the commands the session would accept right now. Use this "
+            "to enable or grey out controls instead of re-deriving the state "
+            "machine client-side; any command not listed would be rejected."
+        )
+    )
+
+
+class StreamStarted(ModelMessage):
+    """Emitted when `start` begins the continuous chain.
+
+    The first clip is generated from the held prompt (text-to-video-and-audio);
+    every clip after is anchored on the previous clip's last frame, so the
+    stream continues off the one prompt with no further input.
+    """
+
+    prompt: str = MessageField(description="The held prompt the chain is generating from.")
+    aspect: str = MessageField(description="Aspect ratio the chain is generating at.")
+    width: int = MessageField(description="Width of every frame on `main_video`.")
+    height: int = MessageField(description="Height of every frame on `main_video`.")
+    clip_seconds: float = MessageField(description="Length of each generated clip, in seconds.")
+    seed: int = MessageField(description="Seed the chain's first clip generated from.")
+
+
+class ClipComplete(ModelMessage):
+    """Emitted each time a clip has been stitched into the stream and sent.
+
+    Progress, not a handle: the chain is one continuous video, so this reports
+    how far it has run rather than naming a clip a client can act on.
+    """
+
+    index: int = MessageField(description="The clip's position in the chain, starting at 0.")
+    frames: int = MessageField(description="Frames the clip contributed before seam overlap.")
+    prompt: str = MessageField(
+        description="The held prompt in force when this clip was generated."
+    )
+    seconds_sent: float = MessageField(
+        description="Seconds of video and audio sent since the stream started, this clip included."
+    )
+
+
+class StreamStopped(ModelMessage):
+    """Emitted when `stop` ends the chain, or it stops on a lost audience.
+
+    The stream flushes to black. A later `start` begins a fresh chain from the
+    held prompt's first clip.
+    """
+
+    clips_emitted: int = MessageField(description="Clips stitched into the stream before it ended.")
+    seconds_sent: float = MessageField(
+        description="Seconds of video and audio sent over the whole run."
+    )
+
+
+class PromptAccepted(ModelMessage):
+    """Emitted when `set_prompt` is accepted.
+
+    Held for the rest of the session unless changed. Set before `start` it is
+    the chain's prompt; set during a run it swaps in for the next clip generated,
+    steering the stream without interrupting it.
+    """
+
+    prompt: str = MessageField(description="The held prompt now in force.")
+    applied_live: bool = MessageField(
+        description="True when a chain was already running and the new prompt takes the next clip."
+    )
+
+
+class SeedAccepted(ModelMessage):
+    """Emitted when `set_seed` is accepted."""
+
+    seed: int = MessageField(description="Seed the next chain's first clip will generate from.")
+
+
+class ClipLengthAccepted(ModelMessage):
+    """Emitted when `set_clip_seconds` is accepted.
+
+    The requested length is snapped to the nearest length the model can produce,
+    so the value here may differ slightly from the one sent.
+    """
+
+    clip_seconds: float = MessageField(description="Clip length now in effect, in seconds.")
+    frames: int = MessageField(description="Frames each generated clip will carry.")
+
+
+class CanvasAccepted(ModelMessage):
+    """Emitted when `set_canvas` is accepted."""
+
+    aspect: str = MessageField(description="Aspect ratio now in effect.")
+    width: int = MessageField(description="Width of every frame on `main_video`.")
+    height: int = MessageField(description="Height of every frame on `main_video`.")
+
+
+class SessionReset(ModelMessage):
+    """Emitted when `reset` is accepted.
+
+    Every condition is back to its default, any running chain is cut, and the
+    output stream is cleared.
+    """
+
+    was_streaming: bool = MessageField(
+        description="A chain was running and has been cut; a `stream_stopped` accompanies it."
+    )
+
+
+class CommandError(ModelMessage):
+    """Emitted when a command is rejected. The command had no effect."""
+
+    command: str = MessageField(description="Name of the command that was rejected.")
+    reason: str = MessageField(description="Why it was rejected.")

--- a/fast-h3-live/reactor.yaml
+++ b/fast-h3-live/reactor.yaml
@@ -1,0 +1,131 @@
+# Reactor model specification for the FastH3 live (continuous-chain) channel.
+#
+# A sibling of the hard-cut `fast-h3` channel: same engine, same 148 GB
+# checkpoint, same solved infrastructure (see the shared notes below), but the
+# model chains clips into one continuous stream from a single held prompt
+# instead of playing a queue of independent clips with a black flush between.
+# Only the model name, the runtime import, the config file, and this
+# description differ from `fast-h3/reactor.yaml`; the build and resource blocks
+# are identical because the engine and its kernels are.
+$schema: reactor/v1
+
+model:
+  name: fast-h3-live
+  # Bare semver, no `v` prefix — the platform's release tag format; the
+  # registration validator refuses a prefixed one.
+  version: 0.1.0
+  description: |
+    Generate one continuous 768p video-and-audio stream from a single prompt.
+    MiniMax-H3 (35B), distilled by FastVideo to four transformer forwards with
+    90% sparse video attention, generates clip after clip off the one prompt —
+    the first text-to-video, every clip after FL2VA-anchored on the previous
+    clip's last frame — and stitches them at the seam (linear-light crossfade,
+    per-clip color-match, equal-power audio) so the result plays as one video.
+    `start` begins the chain, `stop` ends it, `set_prompt` steers it live.
+  # Eight Blackwell GPUs: the count that builds faster than the stream plays
+  # (~12.9 s for a 15 s clip on eight B200s, against ~15.5-17 s on four). A
+  # continuous chain needs builds to outpace playback or every clip boundary
+  # waits on the GPUs, so the extra four buy the realtime headroom, not just
+  # shorter startup waits. The count must divide H3's 56 attention heads
+  # (1, 2, 4, 7, 8 …). The image serves B200 and B300 (Blackwell Ultra,
+  # compute capability 10.3) with the same profile; its kernels are compiled
+  # for both 10.0a and 10.3a — see TORCH_CUDA_ARCH_LIST below.
+  #
+  # The CPU allocation is measured, not guessed. The engine runs nine
+  # processes (the runtime plus eight spawned workers), and NCCL host
+  # threads, kernel-launch threads, and the decode gather all burn CPU
+  # between collectives. At request 8 / limit 32 on a 192-vCPU HGX B200
+  # node the cgroup throttled 38% of CFS periods and the pod built at
+  # 0.85x realtime against 1.16x on identical unthrottled silicon. Request
+  # and limit are both pinned at the account's model CPU quota (the registry
+  # 429s any limit above it), and OMP_NUM_THREADS in runtime_env stops the
+  # over-threading that amplified the throttle.
+  #
+  # memory: with nothing CPU-offloaded the host holds the load-time transient
+  # of eight ranks streaming a 148 GB bundle plus the double-buffer of built
+  # clips (bounded by inference.buffer_depth in live_h3.yaml — a couple of
+  # clips of uint8 pixels). If the offload flags in live_h3.yaml are turned
+  # back on, memory must rise to several hundred Gi (8 ranks × ~63 GB pinned)
+  # — see the note there.
+  resources:
+    gpu:
+      type: NVIDIA_B200
+      count: 8
+    cpu:
+      request: "64"
+      limit: "64"
+    # Sized for the resident text encoder: on eight dedicated Blackwell GPUs
+    # each rank holds its own copy in VRAM (live_h3.yaml turns the offload
+    # off), so the host carries only the load transient and the double-buffer.
+    memory:
+      request: 64Gi
+      limit: 256Gi
+
+runtime:
+  import: live_h3:LiveH3
+  config: live_h3.yaml
+  # The weights bundle is the same checkpoint the hard-cut channel serves;
+  # point at the shared bundle so it is not uploaded twice.
+  weights_path: ~/.cache/reactor_registry/fast-h3
+  # Left off until gap-free continuity is confirmed on a GPU pass. The seams
+  # are stitched (no hard cuts), so a recording would be continuous — but
+  # whether generation keeps ahead of playback at 768p is not yet validated;
+  # enable it once it is.
+  recording:
+    enabled: false
+
+build:
+  runtime_version: "3.2.6"
+  python_requirements: requirements.txt
+  # CUDA 13 is the model's requirement, not a preference: the VSA-H3 sparse
+  # kernel and the FA4 CuTe kernels are both cu130 builds.
+  cuda_version: "13.1.2"
+  python_version: "3.12"
+  # ninja keeps any torch BuildExtension parallel. git is what pip drives to
+  # resolve the `git+https` flash-attn-4 requirement. libgl1 + libglib2.0-0
+  # are for opencv: fastvideo depends on `opencv-python` (the GUI build), so
+  # the GUI shared libraries have to be present or the first `import cv2` dies
+  # on `libGL.so.1`.
+  system_packages:
+    - build-essential
+    - ffmpeg
+    - git
+    - libgl1
+    - libglib2.0-0
+    - ninja-build
+  # torch comes from the cu130 index in requirements.txt; UV_OVERRIDE feeds the
+  # requirements back in as resolver overrides, which is what lets the runtime's
+  # protobuf>=7.35.1 defeat cutlass-dsl's stale <7 cap — see the protobuf note
+  # in requirements.txt.
+  build_env:
+    UV_INDEX_STRATEGY: unsafe-best-match
+    UV_OVERRIDE: /app/requirements.txt
+    # fastvideo-kernel and flash-attn-4 compile from source during the build.
+    # Arch-specific (`a`) binaries do not run forward even within a family, so
+    # the list carries both Blackwell (10.0a, B200) and Blackwell Ultra
+    # (10.3a, B300). The kernel package's Python-side gate only accepts
+    # (10, 0) — sitecustomize.py widens it to this list; keep the two in sync
+    # (_VSA_BUILT_CAPABILITIES). When this list changes, build once with
+    # UV_NO_CACHE=1: uv keys its built-wheel cache on the source revision alone.
+    TORCH_CUDA_ARCH_LIST: "10.0a;10.3a"
+    CMAKE_BUILD_PARALLEL_LEVEL: "32"
+    MAX_JOBS: "32"
+  # Long-lived server allocating a clip's worth of pixels over and over:
+  # expandable-segments is what stops fragmentation creeping across a
+  # multi-hour chain. Offline turns a missing bundle file into a clear error
+  # instead of a hang. PYTHONPATH=/app is load-bearing: it makes every
+  # interpreter in the container — the runtime and each spawned engine worker —
+  # import /app/sitecustomize.py at start, the only place its two fixes can
+  # land inside the workers: raising dynamo's recompile limit and widening the
+  # VSA kernel's device gate to every arch in TORCH_CUDA_ARCH_LIST above.
+  runtime_env:
+    PYTORCH_ALLOC_CONF: expandable_segments:True
+    HF_HUB_OFFLINE: "1"
+    TRANSFORMERS_OFFLINE: "1"
+    PYTHONPATH: /app
+    FASTH3_DYNAMO_RECOMPILE_LIMIT: "64"
+    # torch sizes its intra-op threadpools from nproc, which reports the whole
+    # node inside the container, so nine processes pile thousands of runnable
+    # threads against the CPU quota and CFS throttles them. Eight threads per
+    # process keeps the total under resources.cpu.
+    OMP_NUM_THREADS: "8"

--- a/fast-h3-live/requirements.txt
+++ b/fast-h3-live/requirements.txt
@@ -1,0 +1,45 @@
+# Model dependencies resolved with Reactor Runtime during `reactor build`.
+# `build.runtime_version` in reactor.yaml selects the Runtime release.
+--extra-index-url https://download.pytorch.org/whl/cu130
+
+# The cu130 builds the sparse-attention and FA4 kernels are compiled against.
+# 2.12.0 is what fastvideo 0.2.1 pins. torchvision and torchaudio are pinned
+# exactly, because UV_OVERRIDE (see below) strips their own torch coupling
+# from resolution: 0.27.x is the torchvision built against torch 2.12, and
+# 2.11.0 is the newest torchaudio the cu130 index carries — fine here, since
+# the only torchaudio surface this model touches (`functional.resample`) is
+# pure torch ops, not its compiled extension.
+torch==2.12.0
+torchaudio==2.11.0
+torchvision==0.27.1
+
+# The inference stack: pipelines, the MiniMax-H3 model code, the VSA-H3
+# attention backend, and the VideoGenerator engine.
+fastvideo==0.2.1
+
+# The Blackwell sparse-attention kernel, built from source at the 0.3.5
+# release commit rather than installed as the published wheel: the wheel's
+# sm_100a binary fails every launch on driver 595 with "invalid argument",
+# while the same source compiled by the image's CUDA 13.1 nvcc runs correctly
+# (build_env sets TORCH_CUDA_ARCH_LIST=10.0a;10.3a for it, covering B200 and
+# B300; the package's own device gate only accepts (10, 0), which
+# sitecustomize.py widens to match). The PyPI sdist cannot stand in either —
+# it ships without the CUTLASS/ThunderKittens submodules.
+fastvideo-kernel @ git+https://github.com/hao-ai-lab/FastVideo.git@1aed66737739e1fd6ea7271d3306a615a2a6bd55#subdirectory=fastvideo-kernel
+
+# FA4 CuTe kernels for the dense (text and audio) attention paths. Pinned to
+# the revision FastVideo's own `fast-h3` extra selects: it fixes
+# nvidia-cutlass-dsl at 4.6.0.dev0, and an older cutlass-dsl breaks these
+# kernels at JIT time rather than at import.
+flash-attn-4 @ git+https://github.com/Dao-AILab/flash-attention.git@14c377950125c70b7a9dabf9c561fca53715ac7d#subdirectory=flash_attn/cute
+
+# Pinned because cutlass-dsl caps protobuf at <7 while the Reactor Runtime
+# needs >=7.35.1. The cap is over-conservative: protobuf's cross-version
+# guarantee accepts older gencode on a newer runtime, so cutlass-dsl's 6.x
+# gencode runs fine on 7.35. build_env sets UV_OVERRIDE to this file, which
+# turns this line into the resolver-level override that defeats the cap.
+protobuf>=7.35.1
+
+# fasth3.py parses fasth3.yaml itself: the runtime hands over the path to the
+# file `runtime.config` names and does not read it.
+pyyaml

--- a/fast-h3-live/sitecustomize.py
+++ b/fast-h3-live/sitecustomize.py
@@ -1,0 +1,156 @@
+"""Interpreter-wide fixes applied in every process of this deployment.
+
+``reactor.yaml`` sets ``PYTHONPATH=/app``, so CPython imports this
+``sitecustomize`` at interpreter start in every process of the container —
+the runtime and each engine worker FastVideo spawns (never forks —
+``force_spawn``) alike. It installs one import hook that runs a fix right
+after specific third-party modules execute, which is the only point where
+these settings can be corrected: nothing set in the parent carries into a
+spawned worker, and the fixes must land *after* the module code that writes
+the value being fixed. Two fixes ride the hook:
+
+**Dynamo recompile limits.** Every distinct clip length is a torch.compile
+shape, and the regional-compile route runs fullgraph, where exceeding
+dynamo's recompile limit is a hard failure (``FailOnRecompileLimitHit``)
+that kills the engine workers and the serving process with them. torch 2.12
+maps no environment variable onto the limit, and FastVideo's own imports
+lower it (``layers/lora/linear.py`` sets ``recompile_limit = 16``,
+``third_party/longcat_video/.../bsa_interface.py`` sets
+``cache_size_limit = 32``), so the hook re-raises the limits after
+``torch._dynamo.config`` and after each of those two modules execute — the
+highest setting wins no matter the import order. The limit comes from
+``FASTH3_DYNAMO_RECOMPILE_LIMIT`` (default 64 — 14 legal clip lengths times
+the warmed canvases, with room to spare).
+
+**The VSA kernel's arch gate.** The image compiles ``fastvideo-kernel``
+for every architecture in ``TORCH_CUDA_ARCH_LIST`` (reactor.yaml), but
+``block_sparse_attn_sm100a.is_supported`` compares the device capability
+against a ``(10, 0)`` constant by equality — written when B200 was the only
+Blackwell. On a B300 (capability ``(10, 3)``) the embedded sm_103a binary
+is present and correct, yet the gate refuses it, and because the same
+predicate decides regional compile, the deployment silently drops to the
+~2.5x-slower Triton kernels *in eager mode* (measured 0.74x realtime on
+eight B300s against >1x with the fast route). The hook replaces the
+constant with a value equal to every capability the build carries.
+
+Nothing here imports torch: interpreters that never touch these modules
+(build tooling, small subprocesses) pay only for registering the hook.
+"""
+
+from __future__ import annotations
+
+import importlib.abc
+import importlib.util
+import os
+import sys
+from collections.abc import Callable
+
+# Device capabilities the image's fastvideo-kernel build embeds SASS for —
+# the tuple form of TORCH_CUDA_ARCH_LIST in reactor.yaml (10.0a → (10, 0)).
+# Keep the two in sync: listing an arch the build lacks would send the
+# kernel launches of that device to a missing binary instead of Triton.
+_VSA_BUILT_CAPABILITIES = ((10, 0), (10, 3))
+
+
+def _raise_limits() -> None:
+    config = sys.modules.get("torch._dynamo.config")
+    if config is None:
+        return
+    limit = int(os.environ.get("FASTH3_DYNAMO_RECOMPILE_LIMIT", "64"))
+
+    def lift(name: str, floor: int) -> None:
+        current = getattr(config, name, None)
+        if isinstance(current, int) and current < floor:
+            setattr(config, name, floor)
+
+    lift("recompile_limit", limit)
+    lift("cache_size_limit", limit)
+    # The cross-code-object total; generous so it never binds before the
+    # per-object limit does.
+    lift("accumulated_recompile_limit", max(512, limit * 8))
+    lift("accumulated_cache_size_limit", max(512, limit * 8))
+    config.fail_on_recompile_limit_hit = False
+
+
+class _AnyBuiltCapability:
+    """Equal to every device capability the kernel build carries.
+
+    ``is_supported`` tests the device with ``get_device_capability(...) !=
+    _SM100``; a plain tuple's ``__ne__`` against this object returns
+    ``NotImplemented``, so Python falls through to the reflected operators
+    below, and the gate passes exactly the capabilities whose binaries are
+    embedded in the extension.
+    """
+
+    def __eq__(self, other: object) -> bool:
+        return isinstance(other, tuple) and other in _VSA_BUILT_CAPABILITIES
+
+    def __ne__(self, other: object) -> bool:
+        return not self.__eq__(other)
+
+    def __repr__(self) -> str:
+        return f"<any of {list(_VSA_BUILT_CAPABILITIES)}>"
+
+
+def _widen_vsa_arch_gate() -> None:
+    module = sys.modules.get("fastvideo_kernel.block_sparse_attn_sm100a")
+    if module is None:
+        return
+    # The isinstance keeps the patch idempotent, and stands aside if a
+    # future kernel release reshapes the constant.
+    if isinstance(getattr(module, "_SM100", None), tuple):
+        module._SM100 = _AnyBuiltCapability()
+
+
+# Modules whose import must be followed by a fix; the hook fires after each.
+_ACTIONS: dict[str, Callable[[], None]] = {
+    "torch._dynamo.config": _raise_limits,
+    "fastvideo.layers.lora.linear": _raise_limits,
+    "fastvideo.third_party.longcat_video.block_sparse_attention.bsa_interface": _raise_limits,
+    "fastvideo_kernel.block_sparse_attn_sm100a": _widen_vsa_arch_gate,
+}
+
+
+class _AfterExecLoader(importlib.abc.Loader):
+    """Run the wrapped loader, then the module's fix."""
+
+    def __init__(self, inner, action: Callable[[], None]) -> None:
+        self._inner = inner
+        self._action = action
+
+    def create_module(self, spec):
+        return self._inner.create_module(spec)
+
+    def exec_module(self, module) -> None:
+        self._inner.exec_module(module)
+        self._action()
+
+
+class _FixupFinder(importlib.abc.MetaPathFinder):
+    """Wrap the loaders of the target modules; transparent to everything else."""
+
+    _resolving = False
+
+    def find_spec(self, fullname, path=None, target=None):
+        action = _ACTIONS.get(fullname)
+        if action is None or _FixupFinder._resolving:
+            return None
+        # Resolving the real spec re-enters the import system (parent
+        # packages get imported); the guard keeps that re-entry out of here.
+        _FixupFinder._resolving = True
+        try:
+            spec = importlib.util.find_spec(fullname)
+        finally:
+            _FixupFinder._resolving = False
+        if fullname in sys.modules:
+            # Importing the parents pulled the target in as a side effect;
+            # it is already executed, so patch now and stand aside.
+            action()
+            return None
+        if spec is None or spec.loader is None:
+            return None
+        spec.loader = _AfterExecLoader(spec.loader, action)
+        return spec
+
+
+sys.meta_path.insert(0, _FixupFinder())

--- a/fast-h3-live/tests/test_live_h3.py
+++ b/fast-h3-live/tests/test_live_h3.py
@@ -1,0 +1,747 @@
+"""Live FastH3's seam math, chain control, playout, schema and manifest.
+
+Everything here runs on a laptop: the GPU work sits behind the backend, which
+the chain tests replace with a fake that builds instantly, so the real
+producer/consumer, seam stitching, pacing, emission and teardown all run. The
+seam module is pure numpy and is tested directly.
+
+Run from the model folder: ``PYTHONPATH=. python -m pytest tests/ -q``.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import re
+import time
+from pathlib import Path
+
+import numpy as np
+import pytest
+import yaml
+
+import live_h3_clip_plan as clip_plan
+import live_h3_seam as seam
+from live_h3 import EMIT_FRAMES, SAMPLES_PER_FRAME, LiveH3
+from live_h3_assets import LiveH3Config, load_config
+from live_h3_backend import OUTPUT_SAMPLE_RATE, ClipJob
+
+MODEL_DIR = Path(__file__).resolve().parents[1]
+REPO_ROOT = MODEL_DIR.parent
+FAST_H3_DIR = REPO_ROOT / "fast-h3"
+
+
+# ============================================================ shared-module parity
+#
+# Three files are copied from fast-h3 rather than imported, so the schema renders
+# without torch and the two channels stay independently deployable. These tests
+# are what stop a copy going stale.
+
+
+def test_clip_plan_is_a_verbatim_copy_of_fast_h3():
+    ours = (MODEL_DIR / "live_h3_clip_plan.py").read_text(encoding="utf-8")
+    theirs = (FAST_H3_DIR / "fasth3_clip_plan.py").read_text(encoding="utf-8")
+    assert ours == theirs, "live_h3_clip_plan.py has drifted from fast-h3/fasth3_clip_plan.py"
+
+
+def test_sitecustomize_is_a_verbatim_copy_of_fast_h3():
+    ours = (MODEL_DIR / "sitecustomize.py").read_text(encoding="utf-8")
+    theirs = (FAST_H3_DIR / "sitecustomize.py").read_text(encoding="utf-8")
+    assert ours == theirs, "sitecustomize.py has drifted from fast-h3/sitecustomize.py"
+
+
+def test_requirements_is_a_verbatim_copy_of_fast_h3():
+    ours = (MODEL_DIR / "requirements.txt").read_text(encoding="utf-8")
+    theirs = (FAST_H3_DIR / "requirements.txt").read_text(encoding="utf-8")
+    assert ours == theirs, "requirements.txt has drifted from fast-h3/requirements.txt"
+
+
+def test_clip_geometry_matches_fast_h3():
+    """The copy is exercised, not just diffed: the geometry both channels rely on."""
+    assert clip_plan.FPS == 24
+    assert clip_plan.MIN_FRAMES == 124
+    assert clip_plan.MAX_FRAMES == 345
+    for frames in (1, 100, 124, 200, 345):
+        aligned = clip_plan.align_frames(frames)
+        assert aligned % 17 == 5 and aligned >= frames
+    assert len(clip_plan.legal_frame_counts()) == 14
+
+
+# ================================================================= the seam math
+#
+# Pure numpy: the color-match lock and the linear-light "linearfade" blend.
+
+
+def _gradient_clip(frames: int, base: int) -> np.ndarray:
+    """A small clip whose brightness rises frame to frame, offset by ``base``."""
+    h, w = 8, 8
+    clip = np.zeros((frames, h, w, 3), np.float32)
+    for f in range(frames):
+        clip[f] = base + f * 3
+    return np.clip(clip, 0, 255).astype(np.uint8)
+
+
+def test_reference_rgb_is_the_frames_mean():
+    frame = np.full((4, 4, 3), 120, np.uint8)
+    frame[..., 0] = 40  # a red-shifted frame
+    assert seam.reference_rgb(frame).tolist() == pytest.approx([40.0, 120.0, 120.0])
+
+
+def test_color_match_locks_a_clip_to_the_reference_mean():
+    """A continuation clip's mean RGB is shifted onto clip 0's, once for the clip."""
+    reference = np.array([100.0, 110.0, 120.0], np.float32)
+    clip = _gradient_clip(6, base=200)  # far brighter than the reference
+    matched = seam.color_match_to_reference(clip, reference)
+    assert np.allclose(matched.reshape(-1, 3).mean(0), reference, atol=1.0)
+
+
+def test_color_match_is_one_offset_so_intra_clip_variation_survives():
+    """The per-frame brightness ramp is preserved; only the average moves."""
+    clip = _gradient_clip(6, base=100)
+    before = seam.luma(clip)
+    matched = seam.color_match_to_reference(clip, np.array([50.0, 50.0, 50.0], np.float32))
+    after = seam.luma(matched)
+    # The frame-to-frame differences (the motion/variation) are unchanged.
+    assert np.allclose(np.diff(before), np.diff(after), atol=1.0)
+
+
+def test_color_match_does_not_ratchet_across_a_chain():
+    """Locking every clip to ONE reference keeps the chain mean flat, not drifting.
+
+    Re-deriving the reference from each corrected clip's own last frame (the bug
+    that blew the bear video out to white) would let it climb; this asserts the
+    lock holds it.
+    """
+    reference = seam.reference_rgb(_gradient_clip(6, base=90)[-1])
+    means = []
+    for base in (90, 160, 220, 255):  # successively brighter raw clips
+        matched = seam.color_match_to_reference(_gradient_clip(6, base=base), reference)
+        means.append(matched.reshape(-1, 3).mean(0))
+    spread = np.ptp(np.array(means), axis=0)
+    assert np.all(spread < 3.0), f"clip means drifted across the chain: {means}"
+
+
+def test_linearfade_is_monotonic_with_no_midpoint_flash():
+    """The linear-light complementary blend rises smoothly from tail to head.
+
+    The sRGB equal-power blend it replaces overshoots at the midpoint for
+    near-identical frames — the flash. Between two flat clips the fixed blend's
+    luma must be monotonic and never exceed the brighter endpoint.
+    """
+    tail = np.full((12, 16, 16, 3), 60, np.uint8)  # darker clip tail
+    head = np.full((12, 16, 16, 3), 200, np.uint8)  # brighter clip head
+    blended = seam.blend_video_linear(tail, head)
+    y = seam.luma(blended)
+    assert blended.shape == tail.shape
+    assert np.all(np.diff(y) >= -0.5), f"luma dipped inside the blend: {y}"
+    assert y.max() <= seam.luma(head).max() + 1.0, "blend rose above the brighter endpoint (flash)"
+    assert y.min() >= seam.luma(tail).min() - 1.0
+
+
+def test_linearfade_endpoints_approach_each_clip():
+    """The blend starts near the tail's level and ends near the head's."""
+    tail = np.full((12, 8, 8, 3), 60, np.uint8)
+    head = np.full((12, 8, 8, 3), 200, np.uint8)
+    y = seam.luma(seam.blend_video_linear(tail, head))
+    assert abs(y[0] - seam.luma(tail)[0]) < abs(y[0] - seam.luma(head)[0])
+    assert abs(y[-1] - seam.luma(head)[-1]) < abs(y[-1] - seam.luma(tail)[-1])
+
+
+def test_audio_overlap_is_equal_power_and_never_wraps():
+    """The crossfade holds energy flat and stays inside int16 without wrapping."""
+    fade_out, fade_in = seam.equal_power_ramps(64)
+    assert np.allclose(fade_out**2 + fade_in**2, 1.0, atol=1e-5)
+    tail = np.full((1, 64), 30000, np.int16)
+    head = np.full((1, 64), 30000, np.int16)
+    mixed = seam.blend_audio_equal_power(tail, head)
+    assert mixed.dtype == np.int16
+    assert mixed.shape == (1, 64)
+    assert int(mixed.max()) <= 32767 and int(mixed.min()) >= -32768
+
+
+# ==================================================================== the config
+
+
+def test_the_shipped_config_parses():
+    config = load_config(MODEL_DIR / "live_h3.yaml")
+    assert config.aspect == "16:9"
+    assert config.crossfade_frames == 12
+    assert config.color_match == "per_clip"
+    assert config.buffer_depth == 2
+    assert config.clip_frames == clip_plan.frames_for_seconds(5.167)
+    # "default" warms only the shipped clip length — the live channel's one shape.
+    assert config.warmup_frames == (config.clip_frames,)
+
+
+def test_a_crossfade_at_least_a_clip_long_is_rejected(tmp_path):
+    bad = tmp_path / "xf.yaml"
+    bad.write_text(
+        "inference:\n  clip_seconds: 5.167\n  crossfade_frames: 999\n", encoding="utf-8"
+    )
+    with pytest.raises(ValueError):
+        load_config(bad)
+
+
+def test_an_unknown_color_match_mode_is_rejected(tmp_path):
+    bad = tmp_path / "cm.yaml"
+    bad.write_text("inference:\n  color_match: sometimes\n", encoding="utf-8")
+    with pytest.raises(ValueError):
+        load_config(bad)
+
+
+def test_a_bad_aspect_or_buffer_depth_fails_startup(tmp_path):
+    for body in ("inference:\n  aspect: '32:9'\n", "inference:\n  buffer_depth: 0\n"):
+        path = tmp_path / "bad.yaml"
+        path.write_text(body, encoding="utf-8")
+        with pytest.raises(ValueError):
+            load_config(path)
+
+
+# ========================================================= command contract (state)
+#
+# The real handlers on a model whose ``load()`` never ran: everything they touch
+# is session state and pure arithmetic, so the whole control surface is testable
+# on a laptop.
+
+
+def make_config(clip_frames=6, crossfade_frames=2, buffer_depth=2) -> LiveH3Config:
+    return LiveH3Config(
+        aspect="16:9",
+        clip_frames=clip_frames,
+        seed=1000,
+        num_inference_steps=5,
+        crossfade_frames=crossfade_frames,
+        color_match="per_clip",
+        buffer_depth=buffer_depth,
+        warmup_aspects=("16:9",),
+        warmup_frames=(clip_frames,),
+        inference={},
+        runtime={},
+    )
+
+
+def run(coro):
+    return asyncio.run(coro)
+
+
+def refusal(model):
+    errors = [m for m in model.sent if type(m).__name__ == "CommandError"]
+    return errors[-1] if errors else None
+
+
+@pytest.fixture
+def model():
+    """A LiveH3 with the attributes ``load()`` would have set, and no engine."""
+    instance = LiveH3()
+    instance._on_loop_ready()
+    instance.config = make_config()
+    instance._reset_session_state()
+
+    sent: list = []
+
+    async def capture(message):
+        sent.append(message)
+
+    instance.send = capture
+    instance.sent = sent
+    return instance
+
+
+def test_start_needs_a_held_prompt(model):
+    assert run(model.start()) is None
+    assert refusal(model).command == "start"
+    assert model._streaming is False
+
+
+def test_set_prompt_holds_the_prompt_and_enables_start(model):
+    assert "start" not in run(model.get_state()).valid_commands
+    reply = run(model.set_prompt(prompt="  a bear in a misty forest  "))
+    assert reply.prompt == "a bear in a misty forest"
+    assert reply.applied_live is False
+    assert model._prompt == "a bear in a misty forest"
+    assert "start" in run(model.get_state()).valid_commands
+
+
+def test_an_empty_prompt_is_refused(model):
+    assert run(model.set_prompt(prompt="   ")) is None
+    assert refusal(model).command == "set_prompt"
+    assert model._prompt == ""
+
+
+def test_stop_needs_a_running_chain(model):
+    assert run(model.stop()) is None
+    assert refusal(model).command == "stop"
+
+
+def test_set_seed_and_clip_seconds_take_the_next_chain(model):
+    assert run(model.set_seed(seed=7)).seed == 7
+    assert model._seed == 7
+    reply = run(model.set_clip_seconds(seconds=8.0))
+    assert reply.frames == clip_plan.frames_for_seconds(8.0)
+    assert reply.frames % 17 == 5
+    assert model._clip_frames == reply.frames
+
+
+def test_canvas_is_locked_while_streaming(model):
+    reply = run(model.set_canvas(aspect="9:16"))
+    assert (reply.height, reply.width) == clip_plan.canvas_for_choice("9:16")
+    model._streaming = True
+    assert run(model.set_canvas(aspect="1:1")) is None
+    assert refusal(model).command == "set_canvas"
+    assert model._aspect == "9:16"
+
+
+def test_reset_clears_the_prompt_and_restores_defaults(model):
+    run(model.set_prompt(prompt="a bear"))
+    run(model.set_seed(seed=7))
+    run(model.set_clip_seconds(seconds=8.0))
+    reply = run(model.reset())
+    assert reply.was_streaming is False
+    assert model._prompt == ""
+    assert model._seed == model.config.seed
+    assert model._clip_frames == model.config.clip_frames
+    assert model._aspect == model.config.aspect
+
+
+def test_get_state_publishes_the_live_command_set(model):
+    snapshot = run(model.get_state())
+    assert "start" not in snapshot.valid_commands
+    assert "set_canvas" in snapshot.valid_commands
+    assert snapshot.streaming is False
+    assert snapshot.clips_emitted == 0
+    run(model.set_prompt(prompt="a bear"))
+    assert "start" in run(model.get_state()).valid_commands
+
+
+# ============================================================ the chain, end to end
+#
+# ``_serve`` running a real producer/consumer against a fake backend: the whole
+# held-prompt chain — FL2VA anchoring, the seam stitch, pacing, stop — all run.
+
+FRAMES_PER_CLIP = 6
+
+
+class FakeBackend:
+    """Builds tiny clips on demand; records every submission, anchor included."""
+
+    def __init__(self):
+        self.built: list[dict] = []
+
+    def submit(self, *, frames, prompt, seed, height, width, anchor_image=None) -> ClipJob:
+        self.built.append(
+            {"frames": frames, "prompt": prompt, "seed": seed, "anchored": anchor_image is not None}
+        )
+        job = ClipJob(None)
+        # A distinct grey per clip so color-match has something to move.
+        base = 40 + 30 * (len(self.built) % 4)
+        video = [np.full((height, width, 3), base + f, np.uint8) for f in range(frames)]
+        samples = np.zeros((1, round(frames / 24 * OUTPUT_SAMPLE_RATE)), np.int16)
+        job.result = (video, samples)
+        job.done.set()
+        return job
+
+
+@pytest.fixture
+def live():
+    """A LiveH3 wired to a fake backend, with a connected audience."""
+    instance = LiveH3()
+    instance._on_loop_ready()
+    instance.connected.set()
+    instance.config = make_config()
+    instance._reset_session_state()
+    instance.backend = FakeBackend()
+
+    emitted: list = []
+
+    async def fake_emit(output):
+        emitted.append(output)
+
+    instance.emit = fake_emit
+    instance.emitted = emitted
+
+    messages: list = []
+
+    async def fake_send(message):
+        messages.append(message)
+
+    instance.send = fake_send
+    instance.messages = messages
+
+    instance.output.flush = lambda: None
+    return instance
+
+
+def names(messages) -> list[str]:
+    return [type(m).__name__ for m in messages]
+
+
+def drive(live, scenario):
+    """Run ``_serve`` against a scenario coroutine that ends the session."""
+
+    async def main():
+        async def wrapped():
+            try:
+                await scenario()
+            finally:
+                live.connected.clear()
+
+        await asyncio.gather(live._serve(), wrapped())
+
+    asyncio.run(main())
+
+
+async def eventually(predicate, timeout=4.0):
+    deadline = time.monotonic() + timeout
+    while not predicate():
+        assert time.monotonic() < deadline, "condition never became true"
+        await asyncio.sleep(0.01)
+
+
+def test_one_prompt_drives_an_indefinite_fl2va_chain(live):
+    async def scenario():
+        await live.set_prompt(prompt="a bear in a misty forest")
+        await live.start()
+        await eventually(lambda: live._clips_emitted >= 3)
+        await live.stop()
+        await eventually(lambda: not live._streaming)
+
+    drive(live, scenario)
+    built = live.backend.built
+    assert len(built) >= 3
+    # One held prompt, no re-prompting: every build used the same prompt.
+    assert {b["prompt"] for b in built} == {"a bear in a misty forest"}
+    # The chain: clip 0 is T2VA (no anchor), every clip after is FL2VA-anchored.
+    assert built[0]["anchored"] is False
+    assert all(b["anchored"] for b in built[1:])
+    # The seed advances by one per clip so a run reproduces.
+    assert [b["seed"] for b in built[:3]] == [1000, 1001, 1002]
+    assert "StreamStarted" in names(live.messages)
+    assert "StreamStopped" in names(live.messages)
+    assert live._streaming is False
+
+
+def test_video_and_audio_stay_locked_slice_for_slice(live):
+    async def scenario():
+        await live.set_prompt(prompt="a bear")
+        await live.start()
+        await eventually(lambda: live._clips_emitted >= 2)
+        await live.stop()
+        await eventually(lambda: not live._streaming)
+
+    drive(live, scenario)
+    assert live.emitted, "the chain emitted no frames"
+    for output in live.emitted:
+        video_frames = output.main_video.shape[0]
+        audio_samples = output.main_audio.shape[1]
+        assert output.main_video.dtype == np.uint8
+        assert output.main_audio.dtype == np.int16
+        assert output.main_audio.ndim == 2 and output.main_audio.shape[0] == 1
+        assert audio_samples == video_frames * SAMPLES_PER_FRAME
+
+
+def test_set_prompt_steers_the_chain_mid_stream(live):
+    async def scenario():
+        await live.set_prompt(prompt="scene one")
+        await live.start()
+        await eventually(lambda: live._clips_emitted >= 1)
+        reply = await live.set_prompt(prompt="scene two")
+        assert reply.applied_live is True
+        await eventually(
+            lambda: any(b["prompt"] == "scene two" for b in live.backend.built), timeout=4.0
+        )
+        await live.stop()
+        await eventually(lambda: not live._streaming)
+
+    drive(live, scenario)
+    prompts = [b["prompt"] for b in live.backend.built]
+    assert prompts[0] == "scene one"
+    assert "scene two" in prompts
+
+def test_stop_cuts_the_chain_and_a_restart_begins_fresh(live):
+    async def scenario():
+        await live.set_prompt(prompt="a bear")
+        await live.start()
+        await eventually(lambda: live._clips_emitted >= 2)
+        await live.stop()
+        await eventually(lambda: not live._streaming)
+        # A second start begins a new chain from clip 0 (T2VA) again.
+        live.backend.built.clear()
+        await live.start()
+        await eventually(lambda: live.backend.built and live.backend.built[0]["anchored"] is False)
+        await live.stop()
+        await eventually(lambda: not live._streaming)
+
+    drive(live, scenario)
+    assert names(live.messages).count("StreamStarted") == 2
+
+
+def test_reset_cuts_the_chain_without_a_stream_stopped(live):
+    async def scenario():
+        await live.set_prompt(prompt="a bear")
+        await live.start()
+        await eventually(lambda: live._clips_emitted >= 1)
+        await live.reset()
+        await eventually(lambda: not live._streaming)
+        await asyncio.sleep(0.1)
+
+    drive(live, scenario)
+    # `reset` answers with its own `session_reset` reply (a returned value, not a
+    # broadcast), so the run loop suppresses the `stream_stopped` it would send
+    # for a plain `stop`.
+    assert "StreamStopped" not in names(live.messages)
+    assert live._prompt == ""
+    assert live._streaming is False
+
+
+# --------------------------------------------------------- the seam consumer alone
+#
+# Driving ``_consumer`` on a pre-filled queue proves the frame-count arithmetic:
+# each seam merges the k-frame tail and head into one k-frame blend, so a C-clip
+# chain of N-frame clips emits C*N - (C-1)*k frames.
+
+
+def test_the_seam_removes_exactly_one_overlap_per_boundary():
+    instance = LiveH3()
+    instance._on_loop_ready()
+    instance.config = make_config(clip_frames=6, crossfade_frames=2)
+    instance._reset_session_state()
+
+    emitted: list = []
+
+    async def fake_emit(output):
+        emitted.append(output)
+
+    async def fake_send(message):
+        pass
+
+    instance.emit = fake_emit
+    instance.send = fake_send
+    instance.connected.set()
+
+    n, k, clips = 6, 2, 3
+
+    async def main():
+        queue: asyncio.Queue = asyncio.Queue()
+        for index in range(clips):
+            base = 50 + 20 * index
+            video = np.stack(
+                [np.full((8, 8, 3), base + f, np.uint8) for f in range(n)]
+            )
+            audio = np.zeros((1, n * SAMPLES_PER_FRAME), np.int16)
+            await queue.put((index, "p", video, audio))
+        await queue.put(None)
+        await instance._consumer(queue)
+
+    asyncio.run(main())
+    total = sum(o.main_video.shape[0] for o in emitted)
+    assert total == clips * n - (clips - 1) * k
+    assert instance._frames_sent == total
+    # And every emitted frame is a real uint8 frame with locked audio.
+    for output in emitted:
+        assert output.main_video.dtype == np.uint8
+        assert output.main_audio.shape[1] == output.main_video.shape[0] * SAMPLES_PER_FRAME
+
+
+# ================================================================ published contract
+#
+# ``reactor schema`` compiles this document out of the model class. A change here
+# is a change to every client, so these tests make an accidental one fail loudly.
+
+EXPECTED_COMMANDS = {
+    "get_state": "StateUpdate",
+    "reset": "SessionReset",
+    "set_canvas": "CanvasAccepted",
+    "set_clip_seconds": "ClipLengthAccepted",
+    "set_prompt": "PromptAccepted",
+    "set_seed": "SeedAccepted",
+    "start": None,
+    "stop": None,
+}
+
+EXPECTED_MESSAGES = {
+    "canvas_accepted",
+    "clip_complete",
+    "clip_length_accepted",
+    "command_error",
+    "prompt_accepted",
+    "seed_accepted",
+    "session_reset",
+    "state_update",
+    "stream_started",
+    "stream_stopped",
+}
+
+EXPECTED_REJECTIONS = ("start", "stop", "set_prompt", "set_canvas")
+
+
+@pytest.fixture(scope="module")
+def schema():
+    from reactor_runtime.schema import render
+
+    return render(MODEL_DIR, version="v0.1.0")
+
+
+def test_the_model_publishes_two_outbound_tracks(schema):
+    tracks = schema["x-reactor"]["tracks"]
+    assert [(t["name"], t["kind"], t["direction"]) for t in tracks] == [
+        ("main_video", "video", "out"),
+        ("main_audio", "audio", "out"),
+    ]
+
+
+def test_the_command_set_is_exactly_what_clients_expect(schema):
+    published = {path.removeprefix("/events/") for path in schema["paths"]}
+    assert published == set(EXPECTED_COMMANDS)
+
+
+def test_every_command_answers_with_the_type_it_promises(schema):
+    for name, message in EXPECTED_COMMANDS.items():
+        operation = schema["paths"][f"/events/{name}"]["post"]
+        responses = operation["responses"]
+        if message is None:
+            assert set(responses) == {"202"}, name
+            continue
+        body = responses["200"]["content"]["application/json"]["schema"]
+        assert body["$ref"] == f"#/components/schemas/{message}", name
+
+
+def test_every_message_is_published_once(schema):
+    assert set(schema["webhooks"]) == EXPECTED_MESSAGES
+
+
+def test_the_prompt_is_marked_for_moderation(schema):
+    """`set_prompt` carries client free text into generated video and audio."""
+    properties = schema["paths"]["/events/set_prompt"]["post"]["requestBody"]["content"][
+        "application/json"
+    ]["schema"]["properties"]
+    assert properties["prompt"]["x-reactor-moderate"] is True
+
+
+def test_the_clip_length_bounds_a_client_reads_are_generatable(schema):
+    seconds = schema["paths"]["/events/set_clip_seconds"]["post"]["requestBody"]["content"][
+        "application/json"
+    ]["schema"]["properties"]["seconds"]
+    assert seconds["minimum"] == clip_plan.MIN_SECONDS_PUBLISHED
+    assert seconds["maximum"] == clip_plan.MAX_SECONDS_PUBLISHED
+    for bound in (seconds["minimum"], seconds["maximum"]):
+        assert clip_plan.frames_for_seconds(bound) % 17 == 5
+
+
+def test_the_canvas_choices_are_published_as_an_enum(schema):
+    aspect = schema["paths"]["/events/set_canvas"]["post"]["requestBody"]["content"][
+        "application/json"
+    ]["schema"]["properties"]["aspect"]
+    assert aspect["enum"] == list(clip_plan.ASPECT_CHOICES)
+
+
+def test_every_client_facing_string_is_documented(schema):
+    for path, operations in schema["paths"].items():
+        assert operations["post"].get("summary"), f"{path} has no description"
+        body = operations["post"].get("requestBody")
+        if not body:
+            continue
+        properties = body["content"]["application/json"]["schema"]["properties"]
+        for name, field in properties.items():
+            assert field.get("description"), f"{path} parameter {name} has no description"
+    for name, message in schema["webhooks"].items():
+        assert message["post"].get("summary"), f"message {name} has no description"
+
+
+def test_every_message_summary_says_when_it_is_emitted(schema):
+    for name, message in schema["webhooks"].items():
+        summary = message["post"]["summary"]
+        assert summary.startswith("Emitted "), f"{name}: {summary!r}"
+
+
+def test_no_message_name_repeats_the_model_name(schema):
+    forbidden = ("liveh3", "live-h3", "live_h3", "fasth3", "fast-h3")
+    for name in schema["webhooks"]:
+        assert not name.lower().startswith(forbidden), name
+    for name in schema["components"]["schemas"]:
+        assert not name.lower().startswith(forbidden), name
+
+
+def test_every_refusable_command_documents_its_failure(schema):
+    for name in EXPECTED_REJECTIONS:
+        summary = schema["paths"][f"/events/{name}"]["post"]["summary"]
+        assert "`command_error`" in summary, f"{name} does not document its failure"
+
+
+# ===================================================================== the manifest
+
+WEIGHT_SUFFIXES = {".safetensors", ".ckpt", ".pt", ".pth", ".bin", ".gguf", ".onnx"}
+
+
+@pytest.fixture(scope="module")
+def manifest() -> dict:
+    return yaml.safe_load((MODEL_DIR / "reactor.yaml").read_text(encoding="utf-8"))
+
+
+def test_the_model_name_matches_the_folder(manifest):
+    assert manifest["model"]["name"] == MODEL_DIR.name
+
+
+def test_the_version_is_bare_semver(manifest):
+    version = manifest["model"]["version"]
+    assert isinstance(version, str), "quote the version so it is not parsed as a number"
+    assert re.fullmatch(r"\d+\.\d+\.\d+", version), f"{version!r} must be bare semver"
+
+
+def test_the_manifest_carries_a_complete_resource_spec(manifest):
+    resources = manifest["model"]["resources"]
+    assert resources["gpu"]["type"] and resources["gpu"]["count"] >= 1
+    assert resources["cpu"]["request"] and resources["cpu"]["limit"]
+    assert resources["memory"]["request"] and resources["memory"]["limit"]
+
+
+def test_the_image_is_built_from_the_manifest_not_a_dockerfile(manifest):
+    assert not (MODEL_DIR / "Dockerfile").exists()
+    build = manifest["build"]
+    assert build["python_requirements"] == "requirements.txt"
+    assert (MODEL_DIR / build["python_requirements"]).is_file()
+
+
+def test_the_config_the_runtime_hands_to_load_exists(manifest):
+    config = manifest["runtime"]["config"]
+    assert (MODEL_DIR / config).is_file(), f"runtime.config points at a missing {config}"
+
+
+def test_the_runtime_pin_is_current(manifest):
+    assert manifest["build"]["runtime_version"] == "3.2.6"
+
+
+def test_the_runtime_import_resolves_to_the_model_class(manifest):
+    module_name, _, class_name = manifest["runtime"]["import"].partition(":")
+    module = __import__(module_name)
+    assert getattr(module, class_name, None) is not None, f"{module_name}.py has no {class_name}"
+
+
+def test_no_weights_are_committed_alongside_the_model():
+    offenders = [
+        path.relative_to(MODEL_DIR)
+        for path in MODEL_DIR.rglob("*")
+        if path.is_file()
+        and path.suffix.lower() in WEIGHT_SUFFIXES
+        and not any(part.startswith(".") for part in path.relative_to(MODEL_DIR).parts)
+    ]
+    assert not offenders, f"weights never live in git: {offenders}"
+
+
+def test_the_manifest_build_matches_fast_h3(manifest):
+    """The engine and its kernels are identical, so the build block must be too."""
+    theirs = yaml.safe_load((FAST_H3_DIR / "reactor.yaml").read_text(encoding="utf-8"))
+    assert manifest["build"] == theirs["build"]
+    assert manifest["model"]["resources"] == theirs["model"]["resources"]
+
+
+# ------------------------------------------------------------------ sitecustomize
+
+
+def test_the_built_capabilities_mirror_the_manifest_arch_list(manifest):
+    import sitecustomize
+
+    arch_list = manifest["build"]["build_env"]["TORCH_CUDA_ARCH_LIST"]
+    from_manifest = {
+        tuple(int(part) for part in entry.rstrip("a").split("."))
+        for entry in arch_list.split(";")
+    }
+    assert set(sitecustomize._VSA_BUILT_CAPABILITIES) == from_manifest


### PR DESCRIPTION
Sibling model to fast-h3 (left untouched). Instead of a queue of independent clips with a black flush between, this channel chains clips into one continuous video-and-audio stream from a single held prompt, no re-prompting: clip 0 is T2VA, every clip after is FL2VA-anchored on the previous clip's last frame, and seams are stitched (linear-light "linearfade" crossfade + per-clip color-match locked to clip 0 + equal-power audio overlap) so it plays as one video. A double-buffered producer/consumer keeps generation ahead of playout.

Control surface mirrors fast-h3: set_prompt (steers live), start, stop, reset, set_seed, set_clip_seconds, set_canvas, get_state.

Reuses fast-h3's solved timing fixes: 256-token prompt pad, dynamo recompile-limit raise, and warms BOTH the T2VA and the FL2VA compile shape at load (FL2VA keyframe rows are a distinct shape; unwarmed the first continuation stalls ~20s). sitecustomize.py, requirements.txt and clip_plan are copied verbatim with parity tests.

CPU checks: 50 passed (seam monotonic/no-flash, color-match locks to clip0 and does not ratchet, seam preserves frame counts, held-prompt FL2VA chain end to end, schema/manifest/parity). py_compile clean.

Not yet GPU-validated: gap-free live playback (bimodal timing SHOULD resolve via the carried-over 256-pad/recompile fixes, unconfirmed) and long-run FL2VA quality/drift at 768p (FL2VA is undistilled on this checkpoint; real motion continuity needs a distilled transformer_ref that does not exist here). See fast-h3-live/PR_NOTES.md.