### PR TITLE
feat(fast-h3): continuity mode + color-match/seam fixes + selectable …

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -142,13 +142,28 @@ Director being the queues' only writer (viewer worker, idle filler, and
 - **fast-h3 deliberately subclasses `ReactorModel` with its own `run()` loop**
   (not `ReactorPipeline`): its unit of work is a whole clip, and command
   handlers must answer while a clip builds or plays. Do not "normalize" this.
-- **File seams are fixed.** `fasth3.py` owns commands + the playout loop;
-  `fasth3_types.py` everything a client sees; `fasth3_queue.py` the bounded
-  queue; `fasth3_backend.py` the FastVideo engine + worker thread;
-  `fasth3_assets.py` config parsing and weights validation (the only reader
-  of `fasth3.yaml`); `fasth3_clip_plan.py` pure clip geometry;
-  `fasth3_session_rules.py` which commands each state accepts. New code goes
-  in the seam that owns it. No `__init__.py` — modules import flat.
+- **File seams are fixed.** `fasth3.py` owns commands + both run loops (the
+  queue's playout and continuity's held-prompt take); `fasth3_types.py`
+  everything a client sees; `fasth3_queue.py` the bounded queue;
+  `fasth3_backend.py` the FastVideo engine + worker thread, and continuity's
+  post-decode pipeline that runs on it (FL2VA anchor, GPU exposure lock, GPU
+  seam blend); `fasth3_seam.py` the pure-numpy exposure lock and linear-light
+  crossfade (no torch); `fasth3_assets.py` config parsing and weights validation
+  (the only reader of `fasth3.yaml`); `fasth3_clip_plan.py` pure clip geometry
+  and resolution tiers; `fasth3_session_rules.py` which commands each state
+  accepts, per mode. New code goes in the seam that owns it. No `__init__.py` —
+  modules import flat.
+- **Two modes, one class, disjoint surfaces.** `inference.continuity` (default
+  on) selects a continuous single-prompt take (`set_prompt`, FL2VA-chained,
+  crossfaded into one stream) over the client-driven hard-cut queue
+  (`enqueue`/`play`). Both live in `FastH3`; `run()` dispatches on the
+  per-session `self._continuity` flag (seeded from the config), and the modes
+  share nothing but the engine, tracks, and geometry.
+  `state_update.valid_commands` names the live surface. `set_continuity` flips
+  the flag at runtime while the session is idle; `run()`/`_serve*` re-dispatch
+  on the change, so read `self._continuity`, never `self.config.continuity`, in
+  any per-session path. Keep the queue path byte-for-byte unchanged when
+  continuity is off — the streaming client drives the queue.
 - **Typed contracts.** Every `@event` handler declares and returns a concrete
   `ModelMessage` (or `None`); a refusal broadcasts `command_error` and
   returns bodyless. State-changing commands also broadcast a full

--- a/fast-h3/README.md
+++ b/fast-h3/README.md
@@ -163,19 +163,27 @@ size in force.
 
 ## Commands
 
+The two modes offer disjoint surfaces; `state_update.valid_commands` names the
+live set. `set_prompt` is continuity-only;
+`enqueue`/`play`/`move`/`pop`/`get_queue`/`set_autoplay` are queue-only. The rest
+are shared. `set_continuity` is the runtime toggle between the two — offered
+while the session is idle so a client picks the mode without a config change.
+
 | Command | Parameters | Effect | Rejected when |
 |---|---|---|---|
-| `enqueue` | `prompt` (≤ 800 chars), `metadata` (≤ 2000 chars), `seed` (optional, ≥ 0), `seconds` (optional, 5.167–14.375), `position` (optional, ≥ 0) | Enters the generation queue at `position` (0 = next build; omitted = the back); replies `clip_queued` with the full `ClipInfo`. Without a seed the session's advancing default is used; without `seconds` the session's default length. | generation queue full, empty prompt |
+| `set_prompt` | `prompt` (≤ 800 chars), `metadata` (≤ 2000 chars) | **Continuity mode.** Sets the prompt the continuous take follows; the first starts the take, a later one re-anchors it. Replies `prompt_accepted`. | empty prompt, or the model runs the queue |
+| `enqueue` | `prompt` (≤ 800 chars), `metadata` (≤ 2000 chars), `seed` (optional, ≥ 0), `seconds` (optional, 5.167–14.375), `position` (optional, ≥ 0) | **Queue mode.** Enters the generation queue at `position` (0 = next build; omitted = the back); replies `clip_queued` with the full `ClipInfo`. Without a seed the session's advancing default is used; without `seconds` the session's default length. | generation queue full, empty prompt, or the model runs continuity |
 | `move` | `clip_id` (UUID), `position` (≥ 0) | Repositions the clip within whichever queue holds it; 0 = front, clamped to the back. Replies `clip_moved` with the queue's name and the landing position. | unknown or missing id |
 | `play` | `clip_id` (optional UUID) | Streams the playout queue's front clip, or the named one. Emits `clip_started` as frames begin. | already playing, unknown id, clip still generating |
 | `pop` | `clip_id` (UUID) | Removes that clip from whichever queue holds it, freeing its slot; a build in flight for it is discarded. Replies `clip_popped`. | unknown or missing id |
-| `stop` | — | Cuts the playing clip to black; both queues are untouched. With autoplay on, acts as a skip. Emits `clip_stopped`. | nothing playing |
+| `stop` | — | Cuts the stream to black: the playing clip in queue mode (queues untouched; a skip with autoplay on, emits `clip_stopped`), or the whole continuity take (drops the held prompt back to idle). | nothing playing |
 | `get_queue` | — | Replies with both queues — the same payload as `queue_update`. | — |
 | `set_autoplay` | `enabled` (bool) | On, the playout queue's front clip starts on its own whenever nothing is playing. Off (default), the stream holds until `play`. Replies `autoplay_accepted`. | — |
 | `set_clip_seconds` | `seconds` (5.167–14.375) | Default length for enqueues that carry no `seconds`, snapped to what the model can produce; the effective value returns in `clip_length_accepted`. | — |
 | `set_seed` | `seed` (≥ 0) | Default seed for enqueues that carry none; each such enqueue advances it by one. Replies `seed_accepted`. | — |
 | `set_canvas` | `aspect` (`16:9`, `1:1`, `9:16`, `4:3`) | Video size for the session. Replies `canvas_accepted`. | clips queued or playing, unsupported aspect |
-| `reset` | — | Drops both queues, cuts any playing clip, restores every default. Replies `session_reset`. | — |
+| `set_continuity` | `enabled` (bool) | Switches this session between the continuous take (`true`, the config default) and the hard-cut queue (`false`) at runtime; the config sets the starting mode and `reset` keeps the chosen one. Replies `continuity_accepted`; `state_update.valid_commands` then carries the other mode's surface. | not idle — a clip playing/queued or a prompt held |
+| `reset` | — | Drops both queues, cuts any playing clip, restores every default (keeping the current mode). Replies `session_reset`. | — |
 | `get_state` | — | Replies with the full `state_update` snapshot. | — |
 
 A rejected command has no effect and is answered by a broadcast
@@ -199,6 +207,8 @@ A rejected command has no effect and is answered by a broadcast
 | `seed_accepted` | the caller | Reply to `set_seed`. |
 | `autoplay_accepted` | the caller | Reply to `set_autoplay`. |
 | `canvas_accepted` | the caller | Reply to `set_canvas`. Carries the exact pixel size. |
+| `prompt_accepted` | the caller | Reply to `set_prompt` (continuity). Carries the prompt the take now follows. |
+| `continuity_accepted` | the caller | Reply to `set_continuity`. Carries the mode now in force. |
 | `session_reset` | the caller | Reply to `reset`. Says how many clips were dropped. |
 
 ## Session lifecycle
@@ -260,20 +270,58 @@ instead of re-deriving these rules.
 Playout is a strict 24 fps metronome and the audio is sample-clocked against
 the same rate, so the two tracks stay locked for the length of any clip.
 
-## Clip boundaries are hard cuts
+## Two modes: continuous take, or hard-cut queue
 
-Every clip is generated independently. There is no continuity of subject,
-framing, or voice from one clip to the next, even with identical prompts — and
-the stream holds on black between plays. This checkpoint has no continuation
-path, and inventing one is not an adapter's decision. It is why
-`runtime.recording` is left disabled: a recording would carry those cuts too.
+The model runs one of two modes, fixed at load by `inference.continuity`.
+
+**Continuity (`continuity: true`, the shipped default)** is one continuous
+take. `set_prompt` holds a prompt and the model builds clips back to back
+forever, each after the first FL2VA-anchored on the previous clip's last frame,
+its exposure locked to the opener's, and every boundary crossfaded in linear
+light — so subject, framing and voice carry across as one uninterrupted stream
+until `stop` or a new `set_prompt`. A new `set_prompt` re-anchors: the next clip
+opens fresh on the new prompt and the held seam tail dissolves the old scene
+into it. There is no queue and no `play`; the take starts the moment a prompt is
+set and an audience is connected. The FL2VA and Ref2VA conditioning this uses
+were not distilled into the checkpoint, so the anchored continuation is a
+best-effort carry rather than a trained one — good enough to dissolve a seam,
+not a guaranteed identity lock.
+
+**Queue (`continuity: false`)** is the clip-at-a-time channel described above:
+every clip generated independently, `enqueue`d and `play`ed, the stream holding
+on black between plays with a hard cut at each boundary — no continuity of
+subject, framing, or voice, even with identical prompts. `runtime.recording` is
+left disabled because a recording would carry those cuts. The streaming client
+drives this mode.
+
+The two are **disjoint command surfaces** (`fasth3_session_rules.py`):
+continuity offers `set_prompt`/`stop`/`reset`/`set_seed`/`set_canvas`, the queue
+offers `enqueue`/`play`/`move`/`pop`/… — `state_update.valid_commands` names the
+live set, and the other mode's commands are refused. Everything else (tracks,
+canvas, seed, clip length, warm-up, the engine profile) is shared.
+
+The mode is **config-defaulted but runtime-switchable**: `inference.continuity`
+sets the starting mode, and `set_continuity` flips a session between the two
+while it is idle (nothing playing, queued, or a prompt held — the same gate as
+`set_canvas`), so a client chooses hard cuts or continuity per session without a
+redeploy. `reset` keeps whichever mode is in force. The switch is offered only
+while idle so no clip or take straddles it; the run loop, parked in the current
+mode's idle branch, returns and re-dispatches to the other on the flip.
 
 The geometry it accepts is narrow, and [`fasth3_clip_plan.py`](./fasth3_clip_plan.py)
 encodes it: 24 fps, a frame count of the form `17n + 5`, a duration between 5
-and 15 seconds, a short edge of 768, at most 768×1344 pixels, and both sides a
-multiple of 32. The duration cap has a sharp edge — 15.0 s is 360 frames, which
-aligns *up* to 362 (15.083 s) and is then rejected, so **the longest clip this
-model can make is 345 frames, 14.375 s**.
+and 15 seconds, at most 768×1344 pixels, and both sides a multiple of 32. The
+duration cap has a sharp edge — 15.0 s is 360 frames, which aligns *up* to 362
+(15.083 s) and is then rejected, so **the longest clip this model can make is 345
+frames, 14.375 s**.
+
+The **short edge is a selectable resolution tier**, `inference.canvas_short_edge`
+(a multiple of 32, 256–768), and every `set_canvas` aspect resolves at it. 768 is
+the trained tier every published single-clip number was measured at; 640 (the
+shipped continuity default) makes a 16:9 clip 1152×640 — ~2.9% fewer pixels,
+built proportionally faster, which is the headroom that keeps continuity's
+back-to-back chain ahead of playout. The default is 768 when the key is absent,
+so a queue deployment is unchanged.
 
 ## Determinism
 
@@ -323,8 +371,9 @@ tree arrives through `requirements.txt` and an upgrade is a one-line bump.
 | `fasth3_queue.py` | The bounded clip queue and its entries |
 | `fasth3_backend.py` | The FastVideo engine, its worker thread, warm-up, audio conversion |
 | `fasth3_assets.py` | Config parsing and weights-bundle validation |
-| `fasth3_clip_plan.py` | Clip geometry: valid lengths, frame counts, canvases |
-| `fasth3_session_rules.py` | Which commands each session state accepts |
+| `fasth3_clip_plan.py` | Clip geometry: valid lengths, frame counts, canvases, resolution tiers |
+| `fasth3_seam.py` | Continuity's pure-numpy exposure lock and linear-light seam crossfade (no torch) |
+| `fasth3_session_rules.py` | Which commands each session state accepts, per mode |
 | `fasth3.yaml` | `inference:` the recipe, queue size and warm-up plan, `runtime:` weight layout and engine shape |
 | `reactor.yaml` | The manifest: identity, version, resources, runtime, image build |
 | `sitecustomize.py` | Interpreter-wide fixes in every container process, spawned engine workers included (via `PYTHONPATH=/app`): raises dynamo's recompile limits, widens the VSA kernel's device gate to every built arch |

--- a/fast-h3/fasth3.py
+++ b/fast-h3/fasth3.py
@@ -66,7 +66,9 @@ from fasth3_types import (
     ClipStarted,
     ClipStopped,
     CommandError,
+    ContinuityAccepted,
     FastH3Output,
+    PromptAccepted,
     QueueUpdate,
     SeedAccepted,
     SessionReset,
@@ -153,12 +155,35 @@ class FastH3(ReactorModel):
             job.cancelled = True
             self._build = None
 
-        # Conditions newly enqueued clips snapshot.
-        self._clip_frames: int = self.config.clip_frames
+        # Whether this session runs the continuous take (True) or the hard-cut
+        # clip queue (False). Seeded from the config default; `set_continuity`
+        # flips it at runtime (only while idle), so a client picks the mode
+        # per-session without a redeploy. Everything downstream reads this, not
+        # the config, so the switch is a single source of truth.
+        self._continuity: bool = self.config.continuity
+
+        # Conditions newly enqueued clips snapshot. Continuity holds one length
+        # (the config's continuity_clip_seconds); the queue's default governs
+        # hard-cut. `set_clip_seconds` moves it only in the queue's mode.
+        self._clip_frames: int = (
+            self.config.continuity_clip_frames
+            if self._continuity
+            else self.config.clip_frames
+        )
         self._seed: int = self.config.seed
         self._aspect: str = self.config.aspect
         # Off by default: playback waits for an explicit `play`.
         self._autoplay: bool = False
+
+        # Continuity mode: the held prompt the continuous take follows, whether
+        # a clip is on the wire, and the two edges the run loop watches — a
+        # prompt change (re-anchor) and a stop (drain to black). Unused and
+        # never read in the queue's hard-cut mode.
+        self._prompt: str = ""
+        self._prompt_metadata: str = ""
+        self._prompt_epoch: int = 0
+        self._channel_running: bool = False
+        self._stop_channel: bool = False
 
         # The two queues, and the playout lifecycle around them: builds
         # consume `_generation` from the front and finished clips join the
@@ -177,8 +202,8 @@ class FastH3(ReactorModel):
         self._seconds_sent: float = 0.0
 
     def _canvas(self) -> tuple[int, int]:
-        """The `(height, width)` this session generates at."""
-        return clip_plan.canvas_for_choice(self._aspect)
+        """The `(height, width)` this session generates at, at the configured tier."""
+        return clip_plan.canvas_for_choice(self._aspect, self.config.canvas_short_edge)
 
     def _current_clip(self) -> ClipEntry | None:
         """The clip on (or headed for) the output tracks, if any."""
@@ -192,6 +217,39 @@ class FastH3(ReactorModel):
         Built once here so those three can never disagree.
         """
         height, width = self._canvas()
+        if self._continuity:
+            # The queue fields are neutral: continuity has no queue, only the
+            # single take driven by `set_prompt`. `playing` is the channel on
+            # the wire; the prompt is what it is following.
+            playing = self._channel_running
+            return StateUpdate(
+                clip_seconds=round(clip_plan.seconds_for_frames(self._clip_frames), 3),
+                clip_seconds_min=clip_plan.MIN_SECONDS_PUBLISHED,
+                clip_seconds_max=clip_plan.MAX_SECONDS_PUBLISHED,
+                seed=self._seed,
+                autoplay=False,
+                aspect=self._aspect,
+                width=width,
+                height=height,
+                continuity=True,
+                prompt=self._prompt if playing else "",
+                playing=playing,
+                playing_clip_id=None,
+                generation_queued=0,
+                generation_capacity=0,
+                playout_queued=0,
+                playout_capacity=0,
+                clips_played=self._clips_played,
+                seconds_sent=round(self._seconds_sent, 2),
+                valid_commands=session_rules.valid_commands(
+                    playing=playing,
+                    generation_queued=0,
+                    generation_capacity=0,
+                    playout_queued=0,
+                    continuity=True,
+                    prompt_set=bool(self._prompt),
+                ),
+            )
         current = self._current_clip()
         return StateUpdate(
             clip_seconds=round(clip_plan.seconds_for_frames(self._clip_frames), 3),
@@ -202,6 +260,8 @@ class FastH3(ReactorModel):
             aspect=self._aspect,
             width=width,
             height=height,
+            continuity=False,
+            prompt="",
             playing=current is not None,
             playing_clip_id=current.clip_id if current is not None else None,
             generation_queued=len(self._generation),
@@ -247,6 +307,21 @@ class FastH3(ReactorModel):
         logger.info("command refused", command=command, reason=reason)
         await self.send(CommandError(command=command, reason=reason))
 
+    async def _refuse_queue_only(self, command: str) -> bool:
+        """Refuse a queue-only command while the model runs in continuity mode.
+
+        The two modes are disjoint surfaces; `valid_commands` already hides
+        these, and this is the guard for a client that sends one anyway.
+        """
+        if self._continuity:
+            await self._refuse(
+                command,
+                f"`{command}` drives the clip queue; this stream runs in "
+                "continuity mode — use `set_prompt` to drive it.",
+            )
+            return True
+        return False
+
     # ------------------------------------------------------------ lifecycle
 
     @session_started
@@ -258,6 +333,7 @@ class FastH3(ReactorModel):
     async def on_session_ended(self) -> None:
         """Drop the session's work; the only hook guaranteed to fire on every path."""
         self._stop_playout = True
+        self._stop_channel = True
         self._play_request = None
         if self._build is not None:
             _entry, job, _submitted = self._build
@@ -358,6 +434,8 @@ class FastH3(ReactorModel):
         ),
     ) -> ClipQueued:
         """Append one generation request to the queue."""
+        if await self._refuse_queue_only("enqueue"):
+            return None
         prompt = prompt.strip()
         if not prompt:
             await self._refuse("enqueue", "The prompt is empty; a clip needs one.")
@@ -411,6 +489,8 @@ class FastH3(ReactorModel):
         ),
     ) -> None:
         """Take one ready clip off the queue and hand it to the playout loop."""
+        if await self._refuse_queue_only("play"):
+            return
         if self._current_clip() is not None:
             await self._refuse("play", "A clip is already playing; send `stop` first.")
             return
@@ -460,6 +540,8 @@ class FastH3(ReactorModel):
         ),
     ) -> ClipPopped:
         """Take one clip out of the queue and free its slot."""
+        if await self._refuse_queue_only("pop"):
+            return None
         entry = None
         if clip_id:
             entry = self._generation.get(clip_id) or self._playout.get(clip_id)
@@ -506,6 +588,8 @@ class FastH3(ReactorModel):
         ),
     ) -> ClipMoved:
         """Reposition a clip within its queue."""
+        if await self._refuse_queue_only("move"):
+            return None
         if not isinstance(position, int):
             # The InputField sentinel when called directly.
             position = 0
@@ -529,20 +613,159 @@ class FastH3(ReactorModel):
         return ClipMoved(clip=entry.snapshot(), queue=name, position=landed)
 
     @event(
+        name="set_continuity",
+        description=(
+            "Switch this session between its two modes at runtime, only while "
+            "idle. On (the shipping default): one continuous FL2VA take driven "
+            "by `set_prompt` — every clip is anchored on the previous clip's "
+            "last frame and crossfaded, so one prompt yields an unbroken "
+            "stream. Off: the hard-cut clip queue driven by `enqueue`/`play`, "
+            "each clip an independent cut. The config sets the starting mode; "
+            "this overrides it for the session with no redeploy, and `reset` "
+            "keeps the chosen mode. Accepted only while the stream is idle — "
+            "nothing playing or queued, no prompt held — so no clip or take "
+            "straddles the switch; `stop` or `reset` first otherwise. Emits "
+            "`continuity_accepted` and `state_update` (whose `valid_commands` "
+            "then carries the other mode's surface), or `command_error` when "
+            "the stream is not idle."
+        ),
+    )
+    async def set_continuity(
+        self,
+        enabled: bool = InputField(
+            default=True,
+            description=(
+                "True runs the continuous take (driven by `set_prompt`); false "
+                "runs the hard-cut clip queue (driven by `enqueue`)."
+            ),
+        ),
+    ) -> ContinuityAccepted:
+        """Flip the session between continuity and the hard-cut queue, while idle."""
+        enabled = bool(enabled)
+        if enabled == self._continuity:
+            # Already in this mode: a harmless idempotent ack the client can lean
+            # on without first reading the state back.
+            await self._send_state_update()
+            return ContinuityAccepted(continuity=enabled)
+        # A switch is only safe with nothing on the wire: the run loop is parked
+        # in the current mode's idle branch, so flipping the flag lets it return
+        # and `run()` re-dispatch to the other serve loop. Mirrors set_canvas.
+        if self._continuity:
+            if self._channel_running or self._prompt:
+                await self._refuse(
+                    "set_continuity",
+                    "A prompt is driving the stream; `stop` or `reset` before "
+                    "switching to the hard-cut queue.",
+                )
+                return None
+        elif (
+            self._current_clip() is not None
+            or len(self._generation) > 0
+            or len(self._playout) > 0
+        ):
+            await self._refuse(
+                "set_continuity",
+                "Clips are queued or playing; play the queue out or `reset` "
+                "before switching to continuity.",
+            )
+            return None
+        self._continuity = enabled
+        # Adopt the new mode's default clip length and drop any continuity-only
+        # holds. Idle, so these are already clear — set explicitly for safety.
+        self._clip_frames = (
+            self.config.continuity_clip_frames
+            if enabled
+            else self.config.clip_frames
+        )
+        self._prompt = ""
+        self._prompt_metadata = ""
+        await self._send_state_update()
+        return ContinuityAccepted(continuity=enabled)
+
+    @event(
+        name="set_prompt",
+        description=(
+            "Set the prompt the continuous stream follows (continuity mode "
+            "only). The first `set_prompt` starts the take; a later one "
+            "re-anchors it — the next clip opens fresh on the new prompt and "
+            "every clip after chains from it, so the picture changes over a "
+            "couple of seconds rather than cutting. Holds until the next "
+            "`set_prompt` or `stop`, with no re-prompting in between. Emits "
+            "`prompt_accepted` and `state_update`, or `command_error` when the "
+            "prompt is empty or the model runs the clip queue instead."
+        ),
+    )
+    async def set_prompt(
+        self,
+        prompt: str = InputField(
+            default="",
+            max_length=MAX_PROMPT_CHARS,
+            moderate=True,
+            description=(
+                "What the stream should show, up to 800 characters. The take "
+                "follows it until it is changed again."
+            ),
+        ),
+        metadata: str = InputField(
+            default="",
+            max_length=MAX_METADATA_CHARS,
+            moderate=True,
+            description=(
+                "Free-form string stored with the take and echoed on "
+                "`state_update`. The model never reads it; use it to carry "
+                "display text or your own tracking data."
+            ),
+        ),
+    ) -> PromptAccepted:
+        """Set or change the held prompt the continuity take follows."""
+        if not self._continuity:
+            await self._refuse(
+                "set_prompt",
+                "`set_prompt` drives continuity mode; this stream uses the "
+                "clip queue — `enqueue` a clip instead.",
+            )
+            return None
+        prompt = prompt.strip()
+        if not prompt:
+            await self._refuse("set_prompt", "The prompt is empty; the stream needs one.")
+            return None
+        # A new epoch is the signal the run loop watches: it re-anchors the
+        # chain on the new prompt as a fresh opener instead of carrying the old
+        # prompt's last frame across.
+        self._prompt = prompt
+        self._prompt_metadata = metadata
+        self._prompt_epoch += 1
+        await self._send_state_update()
+        return PromptAccepted(prompt=prompt)
+
+    @event(
         name="stop",
         description=(
-            "Cut the clip that is playing. Whatever is queued on the output "
-            "tracks is dropped, the picture goes to black within a fraction of "
-            "a second, and the session is back where a finished clip leaves it "
-            "— the queue is untouched and the next `play` starts clean. With "
-            "autoplay on this acts as a skip: the next ready clip starts on "
-            "its own, so send `set_autoplay` off first to hold the stream. "
-            "Emits `clip_stopped` and `state_update`, or `command_error` when "
-            "no clip is playing."
+            "Cut what is playing to black within a fraction of a second. In "
+            "continuity mode this ends the take and drops the held prompt, so "
+            "the stream idles on black until a new `set_prompt` starts a fresh "
+            "take. In queue mode whatever is queued on the output tracks is "
+            "dropped and the session is back where a finished clip leaves it — "
+            "the queue is untouched and the next `play` starts clean; with "
+            "autoplay on this acts as a skip, so send `set_autoplay` off first "
+            "to hold the stream. Emits `state_update` (and `clip_stopped` in "
+            "queue mode), or `command_error` when nothing is playing."
         ),
     )
     async def stop(self) -> None:
-        """Ask the playout loop to cut the current clip."""
+        """Ask the playout loop to cut the current clip (or the continuity take)."""
+        if self._continuity:
+            if not self._channel_running:
+                await self._refuse("stop", "No stream is playing.")
+                return
+            # End the take, not just this clip: drop the held prompt so the run
+            # loop parks in idle (black) instead of re-anchoring a fresh take on
+            # the still-held prompt. A new `set_prompt` starts a new take. The
+            # take's own teardown broadcasts the `playing=false` state update.
+            self._stop_channel = True
+            self._prompt = ""
+            self._prompt_metadata = ""
+            return
         if self._current_clip() is None:
             await self._refuse("stop", "No clip is playing.")
             return
@@ -591,6 +814,8 @@ class FastH3(ReactorModel):
         ),
     ) -> ClipLengthAccepted:
         """Set the length newly enqueued clips snapshot."""
+        if await self._refuse_queue_only("set_clip_seconds"):
+            return None
         self._clip_frames = clip_plan.frames_for_seconds(float(seconds))
         await self._send_state_update()
         return ClipLengthAccepted(
@@ -649,6 +874,8 @@ class FastH3(ReactorModel):
         ),
     ) -> AutoplayAccepted:
         """Set whether ready clips start without an explicit `play`."""
+        if await self._refuse_queue_only("set_autoplay"):
+            return None
         self._autoplay = bool(enabled)
         await self._send_state_update()
         return AutoplayAccepted(enabled=self._autoplay)
@@ -677,7 +904,15 @@ class FastH3(ReactorModel):
         ),
     ) -> CanvasAccepted:
         """Set the session's canvas; refused while any clip depends on the old one."""
-        if (
+        if self._continuity:
+            if self._channel_running or self._prompt:
+                await self._refuse(
+                    "set_canvas",
+                    "The canvas is fixed while a prompt drives the stream; "
+                    "`stop` or `reset` first.",
+                )
+                return None
+        elif (
             self._current_clip() is not None
             or len(self._generation) > 0
             or len(self._playout) > 0
@@ -689,7 +924,7 @@ class FastH3(ReactorModel):
             )
             return None
         try:
-            height, width = clip_plan.canvas_for_choice(aspect)
+            height, width = clip_plan.canvas_for_choice(aspect, self.config.canvas_short_edge)
         except ValueError as error:
             await self._refuse("set_canvas", str(error))
             return None
@@ -708,6 +943,20 @@ class FastH3(ReactorModel):
     )
     async def reset(self) -> SessionReset:
         """Clear the session back to its defaults."""
+        if self._continuity:
+            was_playing = self._channel_running
+            if self._channel_running:
+                self._stop_channel = True
+            # Drop the held prompt and re-anchor: a fresh take, nothing carried.
+            self._prompt = ""
+            self._prompt_metadata = ""
+            self._prompt_epoch += 1
+            self._clip_frames = self.config.continuity_clip_frames
+            self._seed = self.config.seed
+            self._aspect = self.config.aspect
+            self.output.flush()
+            await self._send_state_update()
+            return SessionReset(cleared_clips=0, was_playing=was_playing)
         current = self._current_clip()
         was_playing = current is not None
         cleared = self._generation.clear() + self._playout.clear()
@@ -756,7 +1005,179 @@ class FastH3(ReactorModel):
         """
         while True:
             await self.connected.wait()
-            await self._serve()
+            if self._continuity:
+                await self._serve_continuity()
+            else:
+                await self._serve()
+
+    # ---------------------------------------------------------- continuity loop
+
+    async def _serve_continuity(self) -> None:
+        """Drive the single continuous take while an audience is connected.
+
+        Idle (black) until `set_prompt` holds a prompt; then run one take —
+        clips built back to back, FL2VA-anchored and crossfaded into one
+        stream — until `stop`, `reset`, the prompt is dropped, or the audience
+        leaves. Nothing here may raise: the take owns its own failure
+        reporting, and the loop parks back in ``run()`` when the audience goes.
+        A runtime `set_continuity(false)` (only accepted while idle) drops this
+        guard, so the loop returns and ``run()`` re-dispatches to `_serve`.
+        """
+        while self.connected.is_set() and self._continuity:
+            try:
+                if not self._prompt:
+                    self._channel_running = False
+                    self._stop_channel = False
+                    await asyncio.sleep(POLL_SECONDS)
+                    continue
+                await self._run_continuity_take()
+            except Exception:  # noqa: BLE001 — the model loop must survive anything
+                logger.exception("error in the fast-h3 continuity loop")
+                self._channel_running = False
+                self.output.flush()
+                await asyncio.sleep(POLL_SECONDS)
+
+    async def _run_continuity_take(self) -> None:
+        """Stream one held-prompt take, always building one clip ahead.
+
+        Clip 0 opens plain (text-to-video); every later clip is FL2VA-anchored
+        on the previous clip's colour-matched last frame, and the worker
+        crossfades the boundary, so the take is one continuous stream. A
+        ``set_prompt`` mid-take re-anchors: the next clip opens fresh on the new
+        prompt (no first-frame carry-over) and the held seam tail dissolves the
+        old scene into it. The build for clip N+1 is submitted before clip N is
+        emitted, which is what keeps the stream gap-free.
+        """
+        import numpy as np  # noqa: F401 — kept parallel to _emit_continuity
+        from PIL import Image
+
+        height, width = self._canvas()
+        seam_frames = self.config.seam_frames
+        frames = self._clip_frames
+        # Fresh channel state: new exposure reference, no seam tail to blend.
+        self.backend.reset_continuity()
+        self._channel_running = True
+        self._stop_channel = False
+        self._frames_sent = 0
+        self._seconds_sent = 0.0
+        # The emit clock is carried across clips so a seam costs no time.
+        pacer = {"clock_start": None, "frames_paced": 0}
+
+        index = 0
+        prompt = self._prompt
+        take_epoch = self._prompt_epoch
+        started_at = time.monotonic()
+        # Clip 0 opens plain: text-to-video, no first-frame anchor. The take
+        # then chains every later clip on its own colour-matched last frame.
+        job = self.backend.submit_continuity(
+            index=0, frames=frames, prompt=prompt, seed=self._seed,
+            height=height, width=width, anchor=None, seam_frames=seam_frames,
+        )
+        await self._send_state_update()
+
+        try:
+            while True:
+                while not job.done.is_set():
+                    if not self.connected.is_set():
+                        break
+                    await asyncio.sleep(POLL_SECONDS)
+                if not self.connected.is_set() or job.cancelled:
+                    break
+                if job.error is not None:
+                    raise job.error
+                anchor_frame, emit_frames, emit_audio, clip_len = job.result
+                if index == 0:
+                    logger.info(
+                        "continuity first clip ready",
+                        ttff_s=round(time.monotonic() - started_at, 2),
+                        canvas=f"{width}x{height}",
+                    )
+
+                # Decide the next clip: a prompt change opens fresh on the new
+                # prompt (no anchor); otherwise chain FL2VA on this last frame.
+                next_index = index + 1
+                if self._prompt_epoch != take_epoch:
+                    take_epoch = self._prompt_epoch
+                    next_prompt = self._prompt
+                    next_anchor = None
+                else:
+                    next_prompt = prompt
+                    next_anchor = (
+                        Image.fromarray(anchor_frame) if anchor_frame is not None else None
+                    )
+
+                end_take = self._stop_channel or not self._prompt
+                next_job = None
+                if not end_take:
+                    next_job = self.backend.submit_continuity(
+                        index=next_index, frames=frames, prompt=next_prompt,
+                        seed=self._seed + next_index, height=height, width=width,
+                        anchor=next_anchor, seam_frames=seam_frames,
+                    )
+
+                await self._emit_continuity(emit_frames, emit_audio, pacer)
+                self._clips_played += 1
+                await self._send_state_update()
+
+                if next_job is None or self._stop_channel or not self.connected.is_set():
+                    job = next_job
+                    break
+                job, prompt, index = next_job, next_prompt, next_index
+        finally:
+            # A build cannot be cancelled once running; skip it if the worker
+            # has not reached it, then wait it out so the worker is never
+            # wedged behind a take that has already ended.
+            if job is not None:
+                job.cancelled = True
+                while not job.done.is_set() and self._worker_alive():
+                    await asyncio.sleep(POLL_SECONDS)
+            self._channel_running = False
+            self._stop_channel = False
+            self.output.flush()
+            try:
+                await self._send_state_update()
+            except Exception:  # noqa: BLE001 — teardown must not crash the loop
+                logger.exception("failed to send the continuity closing state update")
+
+    def _worker_alive(self) -> bool:
+        """Whether the backend's generation worker is still running."""
+        worker = getattr(self.backend, "_worker", None)
+        return bool(worker is not None and worker.is_alive())
+
+    async def _emit_continuity(self, frames_list, samples, pacer: dict) -> None:
+        """Emit one continuity clip as paced slices, the clock carried in ``pacer``.
+
+        Identical 24 fps metronome to the queue's emitter, except the clock
+        persists across clips (so a seam adds no gap) and the cut condition is
+        the take's `stop`/disconnect rather than a per-clip stop flag. Never
+        bursts to catch up: a late clip re-anchors the clock instead of
+        overflowing the transport.
+        """
+        import numpy as np
+
+        samples_per_frame = OUTPUT_SAMPLE_RATE / FRAME_RATE
+        total = len(frames_list)
+        for lo in range(0, total, EMIT_FRAMES):
+            if self._stop_channel or not self.connected.is_set():
+                return
+            hi = min(lo + EMIT_FRAMES, total)
+            alo = round(lo * samples_per_frame)
+            ahi = round(hi * samples_per_frame)
+
+            now = asyncio.get_running_loop().time()
+            if pacer["clock_start"] is None:
+                pacer["clock_start"] = now
+            content_pos = pacer["frames_paced"] / FRAME_RATE
+            pacer["clock_start"] = max(pacer["clock_start"], now - content_pos)
+            delay = pacer["clock_start"] + content_pos - now
+            if delay > 0:
+                await asyncio.sleep(delay)
+
+            pacer["frames_paced"] += hi - lo
+            self._frames_sent += hi - lo
+            self._seconds_sent = self._frames_sent / FRAME_RATE
+            video = np.ascontiguousarray(np.stack(frames_list[lo:hi]))
+            await self.emit(FastH3Output(main_video=video, main_audio=samples[:, alo:ahi]))
 
     async def _serve(self) -> None:
         """Pump builds and play armed clips while an audience is connected.
@@ -765,8 +1186,11 @@ class FastH3(ReactorModel):
         build is submitted, and the loop parks back in ``run()``. A build
         already on the worker finishes into the queue either way, because a
         clip cannot be cancelled mid-build.
+        A runtime `set_continuity(true)` (only accepted while idle) drops this
+        guard, so the loop returns and ``run()`` re-dispatches to
+        `_serve_continuity`.
         """
-        while self.connected.is_set():
+        while self.connected.is_set() and not self._continuity:
             try:
                 await self._pump_builds()
                 if (

--- a/fast-h3/fasth3.yaml
+++ b/fast-h3/fasth3.yaml
@@ -6,10 +6,16 @@
 
 inference:
   # Aspect the session starts at. `set_canvas` can change it while the queue is
-  # empty and nothing plays, to any entry in clip_plan.ASPECT_CHOICES. 16:9
-  # resolves to 1344x768 — the canvas every published FastH3 number was
-  # measured at.
+  # empty and nothing plays, to any entry in clip_plan.ASPECT_CHOICES.
   aspect: "16:9"
+
+  # Resolution tier the canvas resolves at — the short edge every aspect is
+  # pinned to, in pixels (a multiple of 32, from 256 to 768). 640 is the
+  # shipping default: a 16:9 clip is then 1152x640, ~2.9% fewer pixels than the
+  # 768 tier's 1344x768, which builds proportionally faster and is the headroom
+  # that keeps continuity's gap-free chain ahead of playout. Set 768 for the
+  # full-quality tier every published single-clip number was measured at.
+  canvas_short_edge: 640
 
   # Default clip length in seconds; `set_clip_seconds` changes it per session
   # and each `enqueue` snapshots the value in force. 14.375 s is the longest
@@ -17,6 +23,30 @@ inference:
   # (15.083 s) and is then rejected for exceeding the duration cap, so 345
   # frames is the ceiling.
   clip_seconds: 14.375
+
+  # Continuity mode. Off is the client-driven two-queue channel above: clips
+  # `enqueue`d, `play`ed, hard-cut between. On turns the model into a
+  # self-continuing single-prompt channel — `set_prompt` holds one prompt and
+  # the model builds clips back to back forever, each FL2VA-anchored on the
+  # previous clip's last frame with its exposure locked to the opener's, and
+  # crossfades every boundary in linear light so subject, framing and voice
+  # carry across as one continuous stream until `stop` or a new `set_prompt`.
+  # The two modes are disjoint surfaces (see fasth3_session_rules.py); a
+  # deployment picks one here. The streaming client drives the queue, so it
+  # runs continuity: false.
+  continuity: true
+
+  # Clip length continuity holds to, in seconds (the queue's `clip_seconds`
+  # governs hard-cut mode). Continuity wants short clips: the FL2VA anchor is a
+  # single still, so a shorter clip re-anchors more often, drifts less, and
+  # keeps the builder further ahead of playout. 5.167 s is the shortest the
+  # checkpoint generates and the gap-free-with-margin length at the 640 tier.
+  continuity_clip_seconds: 5.167
+
+  # Seam overlap width in frames (continuity only). The tail of each clip and
+  # the head of the next crossfade across this many frames — linear light for
+  # video, equal-power for audio. At most half a continuity clip. 12 is 0.5 s.
+  seam_frames: 12
 
   # Most built clips the playout queue holds; generation pauses while it is
   # full. Every entry holds a fully built clip in host memory — about 1 GB of
@@ -79,13 +109,13 @@ inference:
   warmup_aspects: ["16:9"]
 
   # Clip lengths warmed at load, each one throwaway build at the primary
-  # canvas: "default" (just clip_seconds), "all" (every legal length — there
-  # are 14, 5.167 s to 14.375 s), or a list of seconds. Every unwarmed length
-  # pays a one-off ~20 s regional-compile stall on its first build. "all"
-  # costs roughly 14 builds of boot time (~5-8 min on four B200s) and is the
-  # right setting for a feed that enqueues arbitrary lengths, like the
-  # streaming client's upsampler.
-  warmup_lengths: "all"
+  # canvas: "default" (just the mode's default length), "all" (every legal
+  # length — there are 14, 5.167 s to 14.375 s), or a list of seconds. Every
+  # unwarmed length pays a one-off ~20 s regional-compile stall on its first
+  # build. Continuity holds one length (continuity_clip_seconds), so "default"
+  # warms exactly what it uses; set "all" for the hard-cut queue, whose feed
+  # enqueues arbitrary lengths (the streaming client's upsampler does).
+  warmup_lengths: "default"
 
 runtime:
   # Weight bundle layout, relative to the mounted weights root. One HF snapshot

--- a/fast-h3/fasth3_assets.py
+++ b/fast-h3/fasth3_assets.py
@@ -51,6 +51,19 @@ class FastH3Config:
     generation_queue_size: int
     warmup_aspects: tuple[str, ...]
     warmup_frames: tuple[int, ...]
+    # Resolution tier the canvas resolves at. 640 (the default) trades pixels
+    # for a proportionally faster build, which is the headroom continuity's
+    # gap-free chain needs; 768 is the measured full-quality tier.
+    canvas_short_edge: int
+    # Continuity mode: off is the client-driven hard-cut queue above; on is a
+    # self-continuing single-prompt channel that FL2VA-anchors each clip on the
+    # previous one's last frame and crossfades the boundary into one stream.
+    continuity: bool
+    # The clip length continuity holds to (shorter than the queue default: a
+    # single-still FL2VA anchor re-anchors more often and drifts less), and the
+    # crossfade overlap width in frames. Both are ignored when continuity is off.
+    continuity_clip_frames: int
+    seam_frames: int
     inference: dict[str, Any]
     runtime: dict[str, Any]
 
@@ -92,6 +105,26 @@ def load_config(config_path: Path | None) -> FastH3Config:
         float(inference.get("clip_seconds", clip_plan.MAX_SECONDS))
     )
 
+    # Absent selects the trained 768 tier, so a config without the key — every
+    # hard-cut deployment — is unchanged; the shipped continuity config sets 640.
+    try:
+        canvas_short_edge = clip_plan.resolve_short_edge(inference.get("canvas_short_edge"))
+    except ValueError as error:
+        raise ValueError(f"inference.canvas_short_edge is invalid: {error}") from None
+
+    continuity = bool(inference.get("continuity", False))
+    continuity_clip_frames = clip_plan.frames_for_seconds(
+        float(inference.get("continuity_clip_seconds", clip_plan.MIN_SECONDS))
+    )
+    seam_frames = int(inference.get("seam_frames", 12))
+    if seam_frames < 0:
+        raise ValueError(f"inference.seam_frames must not be negative, got {seam_frames}")
+    if 2 * seam_frames > continuity_clip_frames:
+        raise ValueError(
+            f"inference.seam_frames ({seam_frames}) is too wide: two seam overlaps "
+            f"must fit one continuity clip ({continuity_clip_frames} frames)."
+        )
+
     return FastH3Config(
         aspect=aspect,
         clip_frames=clip_frames,
@@ -102,7 +135,14 @@ def load_config(config_path: Path | None) -> FastH3Config:
         queue_size=queue_size,
         generation_queue_size=generation_queue_size,
         warmup_aspects=tuple(str(a) for a in (inference.get("warmup_aspects") or [aspect])),
-        warmup_frames=_parse_warmup_lengths(inference.get("warmup_lengths"), clip_frames),
+        warmup_frames=_parse_warmup_lengths(
+            inference.get("warmup_lengths"),
+            continuity_clip_frames if continuity else clip_frames,
+        ),
+        canvas_short_edge=canvas_short_edge,
+        continuity=continuity,
+        continuity_clip_frames=continuity_clip_frames,
+        seam_frames=seam_frames,
         inference=inference,
         runtime=runtime,
     )

--- a/fast-h3/fasth3_backend.py
+++ b/fast-h3/fasth3_backend.py
@@ -84,6 +84,11 @@ class FastH3Backend:
         self._jobs: queue.Queue[ClipJob] = queue.Queue()
         self._worker: threading.Thread | None = None
         self.generator: Any = None
+        # Continuity chain state, carried across a channel's clips on the worker
+        # thread and cleared per channel by reset_continuity: the exposure
+        # reference (clip 0's last-frame mean RGB) and the held seam tail.
+        self._clip0_reference: Any = None
+        self._seam_pacer: dict[str, Any] = {"pending_v": None, "pending_a": None}
 
     # ------------------------------------------------------------------ load
 
@@ -353,7 +358,7 @@ class FastH3Backend:
                 job.done.set()
 
     def submit(self, *, frames: int, prompt: str, seed: int, height: int, width: int) -> ClipJob:
-        """Queue one clip build and hand back its job handle.
+        """Queue one hard-cut clip build and hand back its job handle.
 
         Returns immediately; the caller polls ``job.done`` and reads
         ``job.result`` — ``(frames_list, samples)``, RGB uint8 frames and an
@@ -366,6 +371,55 @@ class FastH3Backend:
         )
         self._jobs.put(job)
         return job
+
+    def submit_continuity(
+        self,
+        *,
+        index: int,
+        frames: int,
+        prompt: str,
+        seed: int,
+        height: int,
+        width: int,
+        anchor,
+        seam_frames: int,
+    ) -> ClipJob:
+        """Queue one continuity clip and hand back its job handle.
+
+        The whole continuity post-decode pipeline runs here on the worker,
+        inside the build-ahead window, so none of it ever stalls the emit
+        metronome: build the clip (FL2VA-anchored on ``anchor`` for every clip
+        but the first), lock its exposure to the chain's opener, take its last
+        colour-matched frame as the next clip's anchor, then crossfade the held
+        tail of the previous clip onto this clip's head. ``job.result`` is
+        ``(anchor_frame, emit_frames, emit_audio, clip_frames)`` — the anchor is
+        an RGB uint8 ``[h, w, 3]`` array, the emit pair is seam-ready. Channel
+        state (the exposure reference and the held seam tail) lives across the
+        chain and is cleared by :meth:`reset_continuity`.
+        """
+        job = ClipJob(
+            lambda: self._build_continuity_clip(
+                index=index,
+                frames=frames,
+                prompt=prompt,
+                seed=seed,
+                height=height,
+                width=width,
+                anchor=anchor,
+                seam_frames=seam_frames,
+            )
+        )
+        self._jobs.put(job)
+        return job
+
+    def reset_continuity(self) -> None:
+        """Clear the continuity chain's carried state, so a restart re-opens clean.
+
+        The exposure reference is re-taken from the next chain's first clip and
+        the seam has no tail to blend, exactly as a fresh channel starts.
+        """
+        self._clip0_reference = None
+        self._seam_pacer: dict[str, Any] = {"pending_v": None, "pending_a": None}
 
     def _run_blocking(self, fn) -> None:
         """Run work on the worker, block until it finishes, and re-raise its failure.
@@ -399,26 +453,33 @@ class FastH3Backend:
         canvas at a non-default length still pays its stall on first use.
         """
         aspects = self._config.warmup_aspects
+        edge = self._config.canvas_short_edge
+        # Continuity holds one length; the queue's default governs hard-cut.
+        default_frames = (
+            self._config.continuity_clip_frames
+            if self._config.continuity
+            else self._config.clip_frames
+        )
         cold = [a for a in clip_plan.ASPECT_CHOICES if a not in aspects]
         if cold:
             logger.info(
                 "aspects left cold; their first clip pays a one-off compile stall", aspects=cold
             )
-        shapes: list[tuple[str, int]] = [
-            (aspect, self._config.clip_frames) for aspect in aspects
-        ]
+        shapes: list[tuple[str, int]] = [(aspect, default_frames) for aspect in aspects]
         shapes += [
             (aspects[0], frames)
             for frames in self._config.warmup_frames
-            if frames != self._config.clip_frames
+            if frames != default_frames
         ]
         logger.info(
             "warm-up plan",
             shapes=len(shapes),
+            short_edge=edge,
+            continuity=self._config.continuity,
             lengths=[round(clip_plan.seconds_for_frames(f), 3) for f in self._config.warmup_frames],
         )
         for index, (aspect, frames) in enumerate(shapes, start=1):
-            height, width = clip_plan.canvas_for_choice(aspect)
+            height, width = clip_plan.canvas_for_choice(aspect, edge)
             started = time.monotonic()
             self.generator.generate(
                 self._request(
@@ -439,6 +500,35 @@ class FastH3Backend:
                 width=width,
                 seconds=round(time.monotonic() - started, 2),
             )
+        # Continuity's continuation clips are FL2VA — a separate compiled shape
+        # from the T2VA opener above. Warm it once at the primary canvas and the
+        # continuity length with a throwaway grey anchor, so the second clip of
+        # a real chain does not pay the ~20 s compile mid-stream.
+        if self._config.continuity:
+            from PIL import Image
+
+            height, width = clip_plan.canvas_for_choice(aspects[0], edge)
+            anchor = Image.new("RGB", (width, height), (128, 128, 128))
+            started = time.monotonic()
+            self.generator.generate(
+                self._request(
+                    frames=default_frames,
+                    prompt=WARMUP_PROMPT,
+                    seed=self._config.seed,
+                    height=height,
+                    width=width,
+                    keep_output=False,
+                    anchor=anchor,
+                )
+            )
+            logger.info(
+                "warmed FL2VA anchor shape",
+                aspect=aspects[0],
+                frames=default_frames,
+                height=height,
+                width=width,
+                seconds=round(time.monotonic() - started, 2),
+            )
 
     # ------------------------------------------------------------ generation
 
@@ -451,16 +541,29 @@ class FastH3Backend:
         height: int,
         width: int,
         keep_output: bool,
+        anchor=None,
     ):
         """Build one generation request.
 
         Mirrors ``basic_fasth3.py:build_request``. ``keep_output=False`` is the
         warm-up shape: it skips the whole post-decode path, so a warm-up costs
-        generation time and nothing else.
+        generation time and nothing else. ``anchor`` — set only in continuity
+        mode — is a PIL image passed as the FL2VA first-frame condition (the
+        previous clip's last frame), which is what carries the scene across a
+        seam; ``None`` is a plain text-to-video build, every hard-cut clip and a
+        continuity chain's first clip.
         """
         from fastvideo.api import GenerationRequest, OutputConfig, SamplingConfig
 
-        return GenerationRequest(
+        inputs = None
+        if anchor is not None:
+            try:
+                from fastvideo.api import InputConfig
+            except ImportError:  # Layout drift across fastvideo releases.
+                from fastvideo.api.schema import InputConfig
+            inputs = InputConfig(pil_image=anchor)
+
+        request_kwargs: dict[str, Any] = dict(
             # Padded to the fixed token length so one compiled shape serves
             # every prompt; ClipInfo keeps echoing the original text.
             prompt=self._pad_prompt(prompt),
@@ -479,13 +582,20 @@ class FastH3Backend:
             ),
             output=OutputConfig(save_video=False, return_frames=keep_output),
         )
+        if inputs is not None:
+            request_kwargs["inputs"] = inputs
+        return GenerationRequest(**request_kwargs)
 
-    def _generate_clip(self, *, frames: int, prompt: str, seed: int, height: int, width: int):
+    def _generate_clip(
+        self, *, frames: int, prompt: str, seed: int, height: int, width: int, anchor=None
+    ):
         """Build one clip and convert it to what the output tracks want.
 
         Returns ``(frames_list, samples)``: a list of RGB uint8 ``[h, w, 3]``
         arrays and int16 ``[1, samples]`` at 48 kHz, trimmed to exactly
         ``len(frames_list) / 24`` seconds so the two tracks stay in lockstep.
+        ``anchor`` (continuity mode only) is the previous clip's last frame,
+        passed as the FL2VA first-frame condition; ``None`` is a plain build.
         """
         started = time.monotonic()
         result = self.generator.generate(
@@ -496,6 +606,7 @@ class FastH3Backend:
                 height=height,
                 width=width,
                 keep_output=True,
+                anchor=anchor,
             )
         )
         built = time.monotonic() - started
@@ -516,6 +627,182 @@ class FastH3Backend:
             f"stages={self._stage_times(result)}"
         )
         return frames_list, samples
+
+    # ---------------------------------------------------------- continuity
+
+    def _build_continuity_clip(
+        self, *, index: int, frames: int, prompt: str, seed: int, height: int, width: int,
+        anchor, seam_frames: int,
+    ):
+        """The continuity pipeline for one clip, start to seam-ready, on the worker.
+
+        Build (FL2VA-anchored past clip 0) -> lock exposure to the chain opener
+        -> take the last colour-matched frame as the next anchor -> crossfade the
+        held tail onto this head. Returns
+        ``(anchor_frame, emit_frames, emit_audio, clip_frames)``.
+        """
+        frames_list, samples = self._generate_clip(
+            frames=frames, prompt=prompt, seed=seed, height=height, width=width, anchor=anchor
+        )
+        frames_list = self._colour_match_clip(index, frames_list)
+        anchor_frame = frames_list[-1] if frames_list else None
+        clip_frames = len(frames_list)
+        if seam_frames > 0:
+            emit_frames, emit_audio = self._stitch_seam(frames_list, samples, seam_frames)
+        else:
+            emit_frames, emit_audio = frames_list, samples
+        return anchor_frame, emit_frames, emit_audio, clip_frames
+
+    def _colour_match_clip(self, index: int, frames_list: list) -> list:
+        """Lock a continuation clip's exposure to the chain opener's last frame.
+
+        Clip 0 sets the reference and is returned untouched; every later clip is
+        shifted by one per-channel offset onto that reference, so exposure stays
+        anchored instead of ratcheting across a long chain. The builds are
+        serialised on this worker, so clip 0's reference is always set before a
+        continuation clip reaches here.
+        """
+        import numpy as np
+
+        import fasth3_seam as seam
+
+        if index == 0 or self._clip0_reference is None:
+            self._clip0_reference = seam.reference_rgb(np.asarray(frames_list[-1]))
+            return frames_list
+        matched = self._colour_match_gpu(frames_list, self._clip0_reference)
+        if matched is not None:
+            return matched
+        # CPU fallback (no CUDA, or the GPU path raised): the same exposure math
+        # in pure numpy over a contiguous block, whose rows are zero-copy views.
+        stacked = np.stack(frames_list)
+        return list(seam.color_match_to_reference(stacked, self._clip0_reference))
+
+    def _colour_match_gpu(self, frames_list: list, reference) -> list | None:
+        """On-GPU exposure lock; ``None`` on any failure so the caller runs numpy.
+
+        The math is identical to :func:`fasth3_seam.color_match_to_reference`:
+        one per-channel additive offset (clip mean -> the reference), clamp,
+        truncate to uint8. The clip mean is reduced in int64/float64 — a device
+        float32 mean over ~10^8 samples collapses exactly as the numpy one does.
+        """
+        try:
+            import numpy as np
+            import torch
+
+            if not torch.cuda.is_available():
+                return None
+            stacked = np.stack(frames_list)
+            with torch.no_grad():
+                t = torch.from_numpy(stacked).to("cuda", non_blocking=True)
+                tgt = torch.from_numpy(np.asarray(reference, np.float32)).to("cuda")
+                n = t.numel() // t.shape[-1]
+                src = (
+                    t.reshape(-1, 3).sum(dim=0, dtype=torch.int64).to(torch.float64) / n
+                ).to(torch.float32)
+                out = (t.to(torch.float32) + (tgt - src)).clamp_(0.0, 255.0).to(torch.uint8)
+                result = out.cpu().numpy()
+            return list(result)
+        except Exception:  # A colour-match must never fail a clip.
+            logger.exception("GPU colour-match failed; falling back to CPU numpy")
+            return None
+
+    def _blend_video_gpu(self, tail_u8, head_u8):
+        """On-GPU linear-light seam crossfade; ``None`` on failure so numpy runs.
+
+        Mirrors :func:`fasth3_seam.blend_video_linear` with ``exposure_match=True``
+        in float32; only the platform's transcendental rounding differs, so the
+        returned ``(k,H,W,3)`` uint8 is within <=1 LSB of the CPU path. The numpy
+        blend is ~3 pow-passes over ``k*H*W*3`` floats (~0.9 s at 640, ~1.3 s at
+        768); on GPU it is a few milliseconds, which is what lets the seam hide
+        inside the build-ahead window.
+        """
+        try:
+            import numpy as np
+            import torch
+
+            if not torch.cuda.is_available():
+                return None
+            k = int(tail_u8.shape[0])
+            if k == 0:
+                return tail_u8[:0]
+            with torch.no_grad():
+                dev = "cuda"
+                t = (
+                    torch.from_numpy(np.ascontiguousarray(tail_u8)).to(dev, non_blocking=True)
+                    .to(torch.float32) / 255.0
+                )
+                h = (
+                    torch.from_numpy(np.ascontiguousarray(head_u8)).to(dev, non_blocking=True)
+                    .to(torch.float32) / 255.0
+                )
+
+                def s2l(s):
+                    s = s.clamp(0.0, 1.0)
+                    return torch.where(s <= 0.04045, s / 12.92, ((s + 0.055) / 1.055) ** 2.4)
+
+                def l2s(l):
+                    l = l.clamp(0.0, 1.0)
+                    return torch.where(l <= 0.0031308, l * 12.92, 1.055 * (l ** (1.0 / 2.4)) - 0.055)
+
+                lt = s2l(t)
+                lh = s2l(h)
+                idx = (torch.arange(k, device=dev, dtype=torch.float32) + 0.5) / k
+                mt = lt.reshape(k, -1, 3).mean(dim=1)
+                mh = lh.reshape(k, -1, 3).mean(dim=1)
+                offset = (mt - mh) * (1.0 - idx[:, None])
+                lh = (lh + offset[:, None, None, :]).clamp(0.0, 1.0)
+                w_in = idx[:, None, None, None]
+                blended = lt * (1.0 - w_in) + lh * w_in
+                out = (l2s(blended).clamp(0.0, 1.0) * 255.0).round().to(torch.uint8)
+                return out.cpu().numpy()
+        except Exception:  # A seam must never fail a clip.
+            logger.exception("GPU seam blend failed; falling back to CPU numpy")
+            return None
+
+    def _stitch_seam(self, frames_list, samples, seam_frames: int):
+        """Turn one clip into its seam-stitched contribution to the stream.
+
+        Holds each clip's last ``seam_frames`` frames (and their audio) in
+        ``self._seam_pacer`` and, on the next clip, crossfades that held tail
+        onto this clip's head — video in linear light with complementary
+        weights, audio equal-power — before the untouched middle. Every boundary
+        removes exactly ``k`` frames (the two overlapping windows become one);
+        the final held tail is dropped when the channel stops.
+        """
+        import numpy as np
+
+        import fasth3_seam as seam
+
+        k = seam_frames
+        n = len(frames_list)
+        spf = OUTPUT_SAMPLE_RATE / FRAME_RATE
+
+        def audio_for(a: int, b: int):
+            return samples[:, round(a * spf) : round(b * spf)]
+
+        prev_v = self._seam_pacer["pending_v"]
+        prev_a = self._seam_pacer["pending_a"]
+
+        new_tail_v = np.ascontiguousarray(np.stack(frames_list[n - k :]))
+        new_tail_a = np.ascontiguousarray(audio_for(n - k, n))
+
+        if prev_v is None:
+            # First clip of the channel: no tail to blend onto, just open.
+            emit_frames = frames_list[: n - k]
+            emit_audio = audio_for(0, n - k)
+        else:
+            head_v = np.ascontiguousarray(np.stack(frames_list[:k]))
+            head_a = audio_for(0, k)
+            blended_v = self._blend_video_gpu(prev_v, head_v)
+            if blended_v is None:
+                blended_v = seam.blend_video_linear(prev_v, head_v)
+            blended_a = seam.blend_audio_equal_power(prev_a, head_a)
+            emit_frames = [np.ascontiguousarray(f) for f in blended_v] + frames_list[k : n - k]
+            emit_audio = np.concatenate([blended_a, audio_for(k, n - k)], axis=1)
+
+        self._seam_pacer["pending_v"] = new_tail_v
+        self._seam_pacer["pending_a"] = new_tail_a
+        return emit_frames, emit_audio
 
     @staticmethod
     def _stage_times(result) -> dict:

--- a/fast-h3/fasth3_clip_plan.py
+++ b/fast-h3/fasth3_clip_plan.py
@@ -27,13 +27,46 @@ _LATENTS_PER_CHUNK = 5
 _MIN_DURATION = 5.0
 _MAX_DURATION = 15.0
 
-# Canvas rules: the short edge is fixed, total area is capped, and both sides
-# must land on a multiple of 32.
+# Canvas rules: the short edge sets the resolution tier, total area is capped,
+# and both sides must land on a multiple of 32. ``_SHORT_EDGE`` is the
+# checkpoint's trained short edge and the default; a deployment can select a
+# lower tier (e.g. 640) through ``inference.canvas_short_edge`` — a smaller
+# clip builds proportionally faster, which is what keeps a continuously fed
+# stream ahead of playout at the cost of pixels. The value flows in as the
+# ``short_edge`` argument below; the module default reproduces the measured
+# 768 profile so every zero-argument caller and the upstream-drift test are
+# unaffected.
 _SHORT_EDGE = 768
 _MAX_PIXELS = 768 * 1344
 _CANVAS_MULTIPLE = 32
 _MIN_ASPECT = 1 / 4
 _MAX_ASPECT = 4
+
+# The resolution tier a deployment may select. The floor keeps a canvas large
+# enough for the checkpoint to stay coherent; the ceiling is the trained short
+# edge, above which the area cap and compile shapes leave the measured profile.
+MIN_SHORT_EDGE = 256
+MAX_SHORT_EDGE = _SHORT_EDGE
+
+
+def resolve_short_edge(short_edge: int | None) -> int:
+    """Validate a configured short edge, or fall back to the trained default.
+
+    A tier must be a multiple of 32 (both canvas sides are) inside
+    ``[MIN_SHORT_EDGE, MAX_SHORT_EDGE]``; ``None`` selects the 768 default.
+    """
+    if short_edge is None:
+        return _SHORT_EDGE
+    edge = int(short_edge)
+    if edge % _CANVAS_MULTIPLE != 0:
+        raise ValueError(
+            f"canvas short edge must be a multiple of {_CANVAS_MULTIPLE}, got {edge}"
+        )
+    if not MIN_SHORT_EDGE <= edge <= MAX_SHORT_EDGE:
+        raise ValueError(
+            f"canvas short edge must be between {MIN_SHORT_EDGE} and {MAX_SHORT_EDGE}, got {edge}"
+        )
+    return edge
 
 
 def align_frames(frames: int) -> int:
@@ -98,12 +131,15 @@ def seconds_for_frames(frames: int) -> float:
     return frames / FPS
 
 
-def canvas_for_aspect(aspect_width: float, aspect_height: float) -> tuple[int, int]:
+def canvas_for_aspect(
+    aspect_width: float, aspect_height: float, short_edge: int = _SHORT_EDGE
+) -> tuple[int, int]:
     """Resolve an aspect ratio to a `(height, width)` the checkpoint accepts.
 
-    Mirrors FastVideo's ``resolve_canvas_size``: pin the short edge to 768,
-    shrink to the area cap if the result is too wide, then round both sides to a
-    multiple of 32.
+    Mirrors FastVideo's ``resolve_canvas_size``: pin the short edge to
+    ``short_edge`` (768 by default, the trained tier), shrink to the area cap if
+    the result is too wide, then round both sides to a multiple of 32. Passing a
+    lower ``short_edge`` selects a lower-resolution tier of the same aspect.
     """
     if aspect_width <= 0 or aspect_height <= 0:
         raise ValueError(f"aspect must be positive, got {aspect_width}:{aspect_height}")
@@ -111,10 +147,11 @@ def canvas_for_aspect(aspect_width: float, aspect_height: float) -> tuple[int, i
     if not _MIN_ASPECT <= ratio <= _MAX_ASPECT:
         raise ValueError(f"aspect ratios run from 1:4 to 4:1, got {aspect_width}:{aspect_height}")
 
+    edge = resolve_short_edge(short_edge)
     if ratio >= 1:
-        width, height = _SHORT_EDGE * ratio, float(_SHORT_EDGE)
+        width, height = edge * ratio, float(edge)
     else:
-        width, height = float(_SHORT_EDGE), _SHORT_EDGE / ratio
+        width, height = float(edge), edge / ratio
     area = width * height
     if area > _MAX_PIXELS:
         scale = (_MAX_PIXELS / area) ** 0.5
@@ -136,19 +173,22 @@ _ASPECT_RATIOS: dict[str, tuple[int, int]] = {
 }
 
 
-def canvas_for_choice(aspect: str) -> tuple[int, int]:
-    """Resolve one of ``ASPECT_CHOICES`` to `(height, width)`."""
+def canvas_for_choice(aspect: str, short_edge: int = _SHORT_EDGE) -> tuple[int, int]:
+    """Resolve one of ``ASPECT_CHOICES`` to `(height, width)` at ``short_edge``."""
     try:
         ratio = _ASPECT_RATIOS[aspect]
     except KeyError:
         raise ValueError(f"unknown aspect {aspect!r}; choose one of {list(ASPECT_CHOICES)}") from None
-    return canvas_for_aspect(*ratio)
+    return canvas_for_aspect(*ratio, short_edge=short_edge)
 
 
 __all__ = [
     "ASPECT_CHOICES",
     "FPS",
     "MAX_FRAMES",
+    "MAX_SHORT_EDGE",
+    "MIN_SHORT_EDGE",
+    "resolve_short_edge",
     "MAX_SECONDS",
     "MAX_SECONDS_PUBLISHED",
     "MIN_FRAMES",

--- a/fast-h3/fasth3_seam.py
+++ b/fast-h3/fasth3_seam.py
@@ -1,0 +1,147 @@
+"""Seam stitching for continuity mode — pure numpy, no torch, no GPU.
+
+Off by default. When ``inference.continuity`` is set, the channel generates each
+clip after the first with FL2VA anchored on the previous clip's last frame, so
+consecutive clips already share a near-identical boundary frame. Two operations
+then turn that sequence into one continuous stream, and both live here so they
+can be tested on any machine; ``fasth3.py`` imports this lazily so rendering the
+schema still needs no numpy.
+
+* :func:`color_match_to_reference` — locks every continuation clip's mean RGB to
+  a single reference (clip 0's last frame). Per-clip (one offset for the whole
+  clip), so intra-clip variation is untouched; anchored to clip 0 rather than the
+  running clip, so exposure cannot ratchet across a long chain.
+
+* :func:`blend_video_linear` — the "linearfade" seam: a crossfade done in
+  **linear light** with **complementary weights** (``w_out + w_in == 1``) plus a
+  ramped local exposure match. Blending in sRGB with equal-power weights
+  overshoots at the midpoint for the near-identical frames FL2VA produces — a
+  visible brightness *flash*. Linear light with complementary weights removes the
+  overshoot; the exposure offset, full at the overlap's start and ramped to zero
+  by its end, keeps the dissolve monotonic with no blend-end pop.
+
+Audio crossfades with equal-power (constant-energy) ramps, which is correct for
+the decorrelated waveforms at a seam (unlike the correlated video frames).
+"""
+
+from __future__ import annotations
+
+import numpy as np
+
+__all__ = [
+    "srgb_to_linear",
+    "linear_to_srgb",
+    "luma",
+    "reference_rgb",
+    "color_match_to_reference",
+    "blend_video_linear",
+    "equal_power_ramps",
+    "blend_audio_equal_power",
+]
+
+
+def srgb_to_linear(s: np.ndarray) -> np.ndarray:
+    """sRGB in [0,1] to linear light. The standard piecewise transfer curve."""
+    s = np.clip(s, 0.0, 1.0)
+    return np.where(s <= 0.04045, s / 12.92, ((s + 0.055) / 1.055) ** 2.4)
+
+
+def linear_to_srgb(l: np.ndarray) -> np.ndarray:
+    """Linear light to sRGB in [0,1]. Inverse of :func:`srgb_to_linear`."""
+    l = np.clip(l, 0.0, 1.0)
+    return np.where(l <= 0.0031308, l * 12.92, 1.055 * (l ** (1.0 / 2.4)) - 0.055)
+
+
+def luma(frames_u8: np.ndarray) -> np.ndarray:
+    """Rec.709 luma per frame, mean over pixels, from uint8 RGB ``(N,H,W,3)``."""
+    f = frames_u8.astype(np.float32)
+    y = 0.2126 * f[..., 0] + 0.7152 * f[..., 1] + 0.0722 * f[..., 2]
+    return y.reshape(y.shape[0], -1).mean(axis=1)
+
+
+def reference_rgb(frame_u8: np.ndarray) -> np.ndarray:
+    """The per-channel mean RGB of one frame — the color-match reference.
+
+    Locked once to clip 0's last frame and held constant for the whole chain, so
+    exposure stays anchored instead of ratcheting.
+    """
+    return frame_u8.reshape(-1, 3).mean(axis=0, dtype=np.float64).astype(np.float32)
+
+
+def color_match_to_reference(frames_u8: np.ndarray, target_rgb: np.ndarray) -> np.ndarray:
+    """Shift a whole clip by ONE per-channel offset so its mean RGB is ``target_rgb``.
+
+    A single offset for every frame — not per-frame — so the clip keeps its
+    natural intra-clip luminance and color variation while its average is pinned
+    to the reference. ``target_rgb`` is clip 0's last-frame mean, constant across
+    the chain, which is what stops exposure drift from compounding.
+    """
+    f = frames_u8.astype(np.float32)
+    # Reduce in float64: a float32 mean over a whole clip (~10^8 samples)
+    # saturates the 24-bit mantissa and collapses — at 124f/768p it returns
+    # ~33.6 instead of the true ~124.5, which would shove every continuation
+    # clip ~90 levels brighter and blow the highlights to white.
+    src = frames_u8.reshape(-1, 3).mean(axis=0, dtype=np.float64).astype(np.float32)
+    f += (target_rgb - src).astype(np.float32)[None, None, None, :]
+    return np.clip(f, 0.0, 255.0).astype(np.uint8)
+
+
+def blend_video_linear(
+    tail_u8: np.ndarray, head_u8: np.ndarray, *, exposure_match: bool = True
+) -> np.ndarray:
+    """Linear-light crossfade of a clip's tail with the next clip's head.
+
+    ``tail_u8`` and ``head_u8`` are the ``(k,H,W,3)`` overlap frames — the last
+    ``k`` of clip N and the first ``k`` of clip N+1. The dissolve runs the head
+    weight from 0 to 1 across the window with complementary weights (``w_out =
+    1 - w_in``) in linear light, so there is no midpoint brightness bump.
+
+    ``exposure_match`` adds a per-frame, per-channel offset that pulls the head
+    onto the tail's mean level at the overlap's start and **ramps to zero** by
+    its end, so the head arrives at its own true level exactly as the body
+    resumes — a constant pin would darken the blend then pop when the body takes
+    over. Returns ``(k,H,W,3)`` uint8.
+    """
+    k = int(tail_u8.shape[0])
+    if k == 0:
+        return tail_u8[:0]
+    lt = srgb_to_linear(tail_u8.astype(np.float32) / 255.0)
+    lh = srgb_to_linear(head_u8.astype(np.float32) / 255.0)
+    if exposure_match:
+        mt = lt.reshape(k, -1, 3).mean(axis=1)
+        mh = lh.reshape(k, -1, 3).mean(axis=1)
+        wr = ((np.arange(k, dtype=np.float32) + 0.5) / k)[:, None]
+        offset = (mt - mh) * (1.0 - wr)  # full at start, zero by the end
+        lh = np.clip(lh + offset[:, None, None, :], 0.0, 1.0)
+    w_in = ((np.arange(k, dtype=np.float32) + 0.5) / k)[:, None, None, None]
+    blended_linear = lt * (1.0 - w_in) + lh * w_in
+    return (np.clip(linear_to_srgb(blended_linear), 0.0, 1.0) * 255.0).round().astype(np.uint8)
+
+
+def equal_power_ramps(n: int) -> tuple[np.ndarray, np.ndarray]:
+    """Equal-power (constant-energy) fade-out/fade-in ramps of length ``n``.
+
+    ``fade_out**2 + fade_in**2 == 1``, the correct crossfade for the decorrelated
+    waveforms at an audio seam — it holds perceived loudness flat where a linear
+    fade would dip.
+    """
+    if n <= 0:
+        return np.ones(0, np.float32), np.ones(0, np.float32)
+    t = (np.arange(n, dtype=np.float32) + 0.5) / n
+    return np.cos(t * (np.pi / 2.0)).astype(np.float32), np.sin(t * (np.pi / 2.0)).astype(np.float32)
+
+
+def blend_audio_equal_power(tail_i16: np.ndarray, head_i16: np.ndarray) -> np.ndarray:
+    """Equal-power overlap-add of two int16 mono waveforms ``(1,S)`` of equal length.
+
+    Blends in float to avoid int16 wrap at the sum, then requantizes. Returns
+    ``(1,S)`` int16.
+    """
+    s = int(min(tail_i16.shape[-1], head_i16.shape[-1]))
+    if s == 0:
+        return np.zeros((1, 0), dtype=np.int16)
+    fade_out, fade_in = equal_power_ramps(s)
+    tail = tail_i16[:, :s].astype(np.float32)
+    head = head_i16[:, :s].astype(np.float32)
+    mixed = tail * fade_out[None, :] + head * fade_in[None, :]
+    return np.clip(mixed, -32768.0, 32767.0).astype(np.int16)

--- a/fast-h3/fasth3_session_rules.py
+++ b/fast-h3/fasth3_session_rules.py
@@ -18,15 +18,38 @@ def valid_commands(
     generation_queued: int,
     generation_capacity: int,
     playout_queued: int,
+    continuity: bool = False,
+    prompt_set: bool = False,
 ) -> list[str]:
     """Name every command the session would accept in this state.
+
+    The two modes are disjoint surfaces. Continuity is the single continuous
+    take driven by `set_prompt`; the queue is the clip-at-a-time channel with
+    `enqueue`/`play`/`move`/`pop`. `state_update.valid_commands` carries the
+    result, so a frontend never offers a command the other mode owns.
 
     Args:
         playing: A clip is streaming on the output tracks.
         generation_queued: Clips waiting in the generation queue.
         generation_capacity: Most clips the generation queue holds.
         playout_queued: Built clips waiting in the playout queue.
+        continuity: The model is in continuity mode.
+        prompt_set: Continuity has a held prompt (the stream is armed or running).
     """
+    if continuity:
+        # The take follows one prompt at one config-fixed length; seed records a
+        # value; the canvas is fixed while a prompt drives the stream, exactly as
+        # it is while the queue holds clips.
+        commands = ["get_state", "reset", "set_prompt", "set_seed"]
+        if playing:
+            commands.append("stop")
+        elif not prompt_set:
+            # The canvas is still free until a prompt fixes it, and while idle
+            # the client may switch this session to the hard-cut queue.
+            commands.append("set_canvas")
+            commands.append("set_continuity")
+        return sorted(commands)
+
     commands = list(_ALWAYS)
     if generation_queued < generation_capacity:
         commands.append("enqueue")
@@ -43,6 +66,8 @@ def valid_commands(
         # empty.
         if generation_queued == 0 and playout_queued == 0:
             commands.append("set_canvas")
+            # Idle: the client may switch this session to continuity mode.
+            commands.append("set_continuity")
     return sorted(commands)
 
 

--- a/fast-h3/fasth3_types.py
+++ b/fast-h3/fasth3_types.py
@@ -100,6 +100,21 @@ class StateUpdate(ModelMessage):
     aspect: str = MessageField(description="Aspect ratio in effect, e.g. `16:9`.")
     width: int = MessageField(description="Width of every frame on `main_video`.")
     height: int = MessageField(description="Height of every frame on `main_video`.")
+    continuity: bool = MessageField(
+        description=(
+            "The stream is a single continuous take driven by `set_prompt`, not "
+            "a queue of separate clips. When true, the queue commands "
+            "(`enqueue`, `play`, `move`, `pop`) do not apply and `valid_commands` "
+            "omits them; when false, `set_prompt` does not apply."
+        )
+    )
+    prompt: str = MessageField(
+        description=(
+            "The prompt the continuous stream is currently following, set by "
+            "`set_prompt`. Empty when nothing is playing, or always in the "
+            "queue's clip-at-a-time mode."
+        )
+    )
     playing: bool = MessageField(description="A clip is streaming on the output tracks.")
     playing_clip_id: str | None = MessageField(
         description="UUID of the clip now playing, or null when the stream is idle."
@@ -275,6 +290,34 @@ class AutoplayAccepted(ModelMessage):
     enabled: bool = MessageField(
         description="Whether ready clips now start on their own when nothing is playing."
     )
+
+
+class ContinuityAccepted(ModelMessage):
+    """Emitted when `set_continuity` switches the session's mode.
+
+    Continuity is on by config default, but a client can flip the session
+    between the continuous take and the hard-cut clip queue at runtime (only
+    while idle). `state_update.valid_commands` then carries the other mode's
+    surface, so a frontend re-draws its controls from the snapshot.
+    """
+
+    continuity: bool = MessageField(
+        description=(
+            "True: the session runs the continuous FL2VA take driven by "
+            "`set_prompt`. False: the hard-cut clip queue driven by `enqueue`."
+        )
+    )
+
+
+class PromptAccepted(ModelMessage):
+    """Emitted when `set_prompt` is accepted in continuity mode.
+
+    The continuous stream re-anchors on the new prompt: the next clip opens
+    fresh on it (no first-frame carry-over from the old prompt), and every clip
+    after chains from that opener until the prompt changes again or `stop`.
+    """
+
+    prompt: str = MessageField(description="The prompt the stream now follows.")
 
 
 class CanvasAccepted(ModelMessage):

--- a/fast-h3/reactor.yaml
+++ b/fast-h3/reactor.yaml
@@ -5,13 +5,14 @@ model:
   name: fast-h3
   # Bare semver, no `v` prefix — the platform's release tag format; the
   # registration validator refuses a prefixed one.
-  version: 0.5.5
+  version: 0.6.0
   description: |
-    Generate 768p video clips with synchronized audio from a queue of prompts.
-    MiniMax-H3 (35B), distilled by FastVideo to four transformer forwards with
-    90% sparse video attention, builds queued clips in order while playback
-    stays a separate, explicit step: enqueue prompts, play any built clip on
-    demand, and the stream holds on black in between.
+    Generate video with synchronized audio from MiniMax-H3 (35B), distilled by
+    FastVideo to four transformer forwards with 90% sparse video attention. Two
+    modes: a continuous single-prompt take that chains and crossfades clips into
+    one uninterrupted stream (`set_prompt`), and a clip queue that builds
+    enqueued prompts in order and plays any built clip on demand
+    (`enqueue`/`play`), holding on black in between.
   # Eight Blackwell GPUs: the count that builds faster than the stream plays
   # (~12.9 s for a 15 s clip on eight B200s, against ~15.5-17 s on four). A
   # 24/7 feed needs builds to outpace playback or every clip boundary waits

--- a/fast-h3/tests/test_fasth3.py
+++ b/fast-h3/tests/test_fasth3.py
@@ -21,9 +21,10 @@ import yaml
 
 import fasth3_clip_plan as clip_plan
 import fasth3_session_rules as session_rules
+import fasth3_seam as seam
 from fasth3 import EMIT_FRAMES, FastH3
 from fasth3_assets import FastH3Config, load_config
-from fasth3_backend import ClipJob
+from fasth3_backend import ClipJob, FastH3Backend
 from fasth3_queue import ClipQueue, new_entry
 from fasth3_types import ClipInfo
 
@@ -287,9 +288,14 @@ def test_the_shipped_config_parses(tmp_path):
     assert config.queue_size == 10
     assert config.aspect == "16:9"
     assert config.clip_frames == clip_plan.MAX_FRAMES
-    # The shipped config warms every legal length: a feed of arbitrary
-    # `seconds` values then never pays a first-use compile stall.
-    assert config.warmup_frames == clip_plan.legal_frame_counts()
+    # The shipped config is the continuous take: continuity on, at the 640 tier,
+    # holding the shortest (gap-free-with-margin) clip length.
+    assert config.continuity is True
+    assert config.canvas_short_edge == 640
+    assert config.continuity_clip_frames == clip_plan.MIN_FRAMES
+    assert config.seam_frames == 12
+    # Continuity holds one length, so the warm-up warms exactly that length.
+    assert config.warmup_frames == (config.continuity_clip_frames,)
 
 
 def test_every_legal_length_is_aligned_and_within_bounds():
@@ -343,7 +349,14 @@ def test_a_bad_aspect_or_queue_size_fails_startup(tmp_path):
 # included — is testable on a laptop.
 
 
-def make_config(queue_size=3, generation_queue_size=None) -> FastH3Config:
+def make_config(
+    queue_size=3,
+    generation_queue_size=None,
+    *,
+    continuity=False,
+    canvas_short_edge=768,
+    seam_frames=12,
+) -> FastH3Config:
     return FastH3Config(
         aspect="16:9",
         clip_frames=clip_plan.frames_for_seconds(clip_plan.MAX_SECONDS),
@@ -353,6 +366,10 @@ def make_config(queue_size=3, generation_queue_size=None) -> FastH3Config:
         generation_queue_size=generation_queue_size or queue_size,
         warmup_aspects=("16:9",),
         warmup_frames=(clip_plan.frames_for_seconds(clip_plan.MAX_SECONDS),),
+        canvas_short_edge=canvas_short_edge,
+        continuity=continuity,
+        continuity_clip_frames=clip_plan.frames_for_seconds(clip_plan.MIN_SECONDS),
+        seam_frames=seam_frames,
         inference={},
         runtime={},
     )
@@ -1034,6 +1051,8 @@ EXPECTED_COMMANDS = {
     "set_autoplay": "AutoplayAccepted",
     "set_canvas": "CanvasAccepted",
     "set_clip_seconds": "ClipLengthAccepted",
+    "set_continuity": "ContinuityAccepted",
+    "set_prompt": "PromptAccepted",
     "set_seed": "SeedAccepted",
     "stop": None,
 }
@@ -1051,6 +1070,8 @@ EXPECTED_MESSAGES = {
     "clip_started",
     "clip_stopped",
     "command_error",
+    "continuity_accepted",
+    "prompt_accepted",
     "queue_update",
     "seed_accepted",
     "session_reset",
@@ -1059,7 +1080,10 @@ EXPECTED_MESSAGES = {
 
 # Commands that can be refused. Each one has to say so in its own summary, and
 # name the message a client will actually receive.
-EXPECTED_REJECTIONS = ("enqueue", "move", "play", "pop", "stop", "set_canvas")
+EXPECTED_REJECTIONS = (
+    "enqueue", "move", "play", "pop", "stop", "set_canvas", "set_prompt",
+    "set_continuity",
+)
 
 # The struct every clip-referencing message embeds, and its JSON types.
 EXPECTED_CLIP_INFO = {
@@ -1373,3 +1397,383 @@ def test_the_built_capabilities_mirror_the_manifest_arch_list(manifest):
         for entry in arch_list.split(";")
     }
     assert set(sitecustomize._VSA_BUILT_CAPABILITIES) == from_manifest
+
+
+# --------------------------------------------------------------------------
+# Continuity mode: the 640 canvas tier, the disjoint command surface, the
+# exposure lock and seam arithmetic, and the held-prompt handlers. The queue's
+# hard-cut path above is unchanged — every test there runs with continuity off.
+
+
+# -- the resolution tier ---------------------------------------------------
+
+
+def test_the_default_short_edge_is_the_measured_tier():
+    """A zero-argument resolve is the 768 tier every published number used."""
+    assert clip_plan.resolve_short_edge(None) == 768
+    assert clip_plan.canvas_for_choice("16:9") == (768, 1344)
+
+
+def test_a_lower_short_edge_selects_a_smaller_canvas():
+    """640 is a real, selectable tier: a true 16:9 rounds to 1152x640."""
+    assert clip_plan.canvas_for_choice("16:9", 640) == (640, 1152)
+
+
+@pytest.mark.parametrize("aspect", clip_plan.ASPECT_CHOICES)
+def test_every_aspect_resolves_at_the_640_tier(aspect):
+    height, width = clip_plan.canvas_for_choice(aspect, 640)
+    assert min(height, width) == 640
+    assert height % 32 == 0 and width % 32 == 0
+    assert height * width <= 768 * 1344
+
+
+def test_short_edge_must_be_a_valid_tier():
+    for bad in (700, 200, 800, 0, -32):
+        with pytest.raises(ValueError):
+            clip_plan.resolve_short_edge(bad)
+    for good in (256, 640, 768):
+        assert clip_plan.resolve_short_edge(good) == good
+
+
+# -- config parsing --------------------------------------------------------
+
+
+def test_the_continuity_config_parses(tmp_path):
+    document = (
+        "inference:\n"
+        "  continuity: true\n"
+        "  canvas_short_edge: 640\n"
+        "  continuity_clip_seconds: 5.167\n"
+        "  seam_frames: 12\n"
+    )
+    path = tmp_path / "continuity.yaml"
+    path.write_text(document, encoding="utf-8")
+    config = load_config(path)
+    assert config.continuity is True
+    assert config.canvas_short_edge == 640
+    assert config.seam_frames == 12
+    assert config.continuity_clip_frames == clip_plan.MIN_FRAMES
+    # Continuity holds one length, so the warm-up warms exactly it.
+    assert config.warmup_frames == (clip_plan.MIN_FRAMES,)
+
+
+def test_continuity_defaults_off_at_the_768_tier(tmp_path):
+    """A config without the continuity keys is the unchanged hard-cut queue."""
+    path = tmp_path / "plain.yaml"
+    path.write_text("inference: {}\n", encoding="utf-8")
+    config = load_config(path)
+    assert config.continuity is False
+    assert config.canvas_short_edge == 768
+
+
+def test_a_too_wide_seam_fails_startup(tmp_path):
+    path = tmp_path / "seam.yaml"
+    path.write_text(
+        "inference:\n  continuity_clip_seconds: 5.167\n  seam_frames: 200\n",
+        encoding="utf-8",
+    )
+    with pytest.raises(ValueError):
+        load_config(path)
+
+
+def test_a_bad_short_edge_fails_startup(tmp_path):
+    path = tmp_path / "edge.yaml"
+    path.write_text("inference:\n  canvas_short_edge: 700\n", encoding="utf-8")
+    with pytest.raises(ValueError):
+        load_config(path)
+
+
+# -- the disjoint command surface -----------------------------------------
+
+
+def test_continuity_offers_the_prompt_surface_not_the_queue():
+    idle = session_rules.valid_commands(
+        playing=False, generation_queued=0, generation_capacity=0,
+        playout_queued=0, continuity=True, prompt_set=False,
+    )
+    assert "set_prompt" in idle and "set_canvas" in idle
+    # Idle: the session may be switched to the hard-cut queue.
+    assert "set_continuity" in idle
+    assert not ({"enqueue", "play", "move", "pop", "get_queue", "set_autoplay"} & set(idle))
+
+    running = session_rules.valid_commands(
+        playing=True, generation_queued=0, generation_capacity=0,
+        playout_queued=0, continuity=True, prompt_set=True,
+    )
+    assert "stop" in running
+    # The canvas is fixed and the mode can no longer be switched once the
+    # take runs.
+    assert "set_canvas" not in running
+    assert "set_continuity" not in running
+
+
+def test_the_queue_surface_never_offers_set_prompt():
+    commands = session_rules.valid_commands(
+        playing=False, generation_queued=0, generation_capacity=10, playout_queued=0,
+    )
+    assert "enqueue" in commands and "set_prompt" not in commands
+
+
+def test_set_continuity_is_offered_only_while_the_queue_is_idle():
+    """The mode switch shares set_canvas's idle gate — empty queues, nothing playing."""
+    idle = session_rules.valid_commands(
+        playing=False, generation_queued=0, generation_capacity=10, playout_queued=0,
+    )
+    assert "set_continuity" in idle
+    # A queued clip fixes the mode until it drains, exactly like the canvas.
+    with_clip = session_rules.valid_commands(
+        playing=False, generation_queued=1, generation_capacity=10, playout_queued=0,
+    )
+    assert "set_continuity" not in with_clip
+    playing = session_rules.valid_commands(
+        playing=True, generation_queued=0, generation_capacity=10, playout_queued=0,
+    )
+    assert "set_continuity" not in playing
+
+
+# -- the exposure lock (the committed float64 fix) -------------------------
+
+
+def test_the_exposure_lock_pins_a_clip_to_the_reference():
+    """color_match shifts a whole clip so its per-channel mean is the target."""
+    rng = np.random.default_rng(0)
+    clip = rng.integers(0, 200, size=(6, 40, 40, 3), dtype=np.uint8)
+    target = np.array([120.0, 130.0, 140.0], np.float32)
+    matched = seam.color_match_to_reference(clip, target)
+    got = matched.reshape(-1, 3).mean(axis=0, dtype=np.float64)
+    # One integer offset for the whole clip, then a uint8 clamp: within a level.
+    assert np.allclose(got, target, atol=1.0)
+
+
+def test_the_reference_is_computed_in_float64():
+    """A wide, high-valued frame's mean must not collapse the way float32 does."""
+    frame = np.full((4000, 4000, 3), 200, np.uint8)
+    reference = seam.reference_rgb(frame)
+    assert np.allclose(reference, 200.0, atol=1e-3)
+    # The float32 mantissa-saturating reduction the bug used would land far off.
+    assert reference.dtype == np.float32 and float(reference[0]) > 199.0
+
+
+def test_the_seam_blend_has_no_midpoint_flash():
+    """Complementary linear-light weights: a constant field blends to itself."""
+    tail = np.full((12, 16, 16, 3), 128, np.uint8)
+    head = np.full((12, 16, 16, 3), 128, np.uint8)
+    blended = seam.blend_video_linear(tail, head)
+    assert blended.shape == (12, 16, 16, 3)
+    assert np.abs(blended.astype(int) - 128).max() <= 1
+
+
+# -- seam stitch arithmetic (on the worker, GPU path falls back to numpy) ---
+
+
+def continuity_backend(seam_frames=12):
+    config = make_config(continuity=True, canvas_short_edge=640, seam_frames=seam_frames)
+    backend = FastH3Backend(config, Path("."))
+    backend.reset_continuity()
+    return backend
+
+
+def test_the_seam_removes_one_overlap_per_boundary():
+    backend = continuity_backend(seam_frames=12)
+    n, k = 124, 12
+    spf = 48_000 / 24
+
+    def clip(value):
+        frames = [np.full((32, 32, 3), value, np.uint8) for _ in range(n)]
+        audio = np.zeros((1, round(n * spf)), np.int16)
+        return frames, audio
+
+    first_frames, first_audio = clip(100)
+    emit0, audio0 = backend._stitch_seam(first_frames, first_audio, k)
+    # Clip 0 opens with its tail held back for the next boundary.
+    assert len(emit0) == n - k
+    assert audio0.shape[-1] == round((n - k) * spf)
+
+    second_frames, second_audio = clip(150)
+    emit1, audio1 = backend._stitch_seam(second_frames, second_audio, k)
+    # Clip 1: k blended frames + the untouched middle = n - k again.
+    assert len(emit1) == n - k
+    assert audio1.shape[-1] == round((n - k) * spf)
+
+
+# -- the held-prompt handlers ----------------------------------------------
+
+
+@pytest.fixture
+def continuity_model():
+    """A continuity-mode FastH3 with the state ``load()`` would set, no engine."""
+    instance = FastH3()
+    instance._on_loop_ready()
+    instance.config = make_config(continuity=True, canvas_short_edge=640)
+    instance._reset_session_state()
+    sent: list = []
+
+    async def capture(message):
+        sent.append(message)
+
+    instance.send = capture
+    instance.sent = sent
+    return instance
+
+
+def test_set_prompt_holds_the_prompt_and_reanchors(continuity_model):
+    reply = run(continuity_model.set_prompt(prompt="a misty forest", metadata="m"))
+    assert reply.prompt == "a misty forest"
+    assert continuity_model._prompt == "a misty forest"
+    epoch = continuity_model._prompt_epoch
+    run(continuity_model.set_prompt(prompt="a city at night", metadata=""))
+    # A changed prompt advances the epoch, the run loop's re-anchor signal.
+    assert continuity_model._prompt == "a city at night"
+    assert continuity_model._prompt_epoch == epoch + 1
+
+
+def test_set_prompt_needs_a_prompt(continuity_model):
+    assert run(continuity_model.set_prompt(prompt="   ", metadata="")) is None
+    assert refusal(continuity_model).command == "set_prompt"
+    assert continuity_model._prompt == ""
+
+
+def test_the_queue_commands_are_refused_in_continuity(continuity_model):
+    assert run(continuity_model.enqueue(prompt="p", metadata="")) is None
+    assert refusal(continuity_model).command == "enqueue"
+    assert run(continuity_model.play(clip_id="")) is None
+    assert refusal(continuity_model).command == "play"
+    assert run(continuity_model.set_autoplay(enabled=True)) is None
+    assert refusal(continuity_model).command == "set_autoplay"
+
+
+def test_set_prompt_is_refused_in_the_queue_mode(model):
+    assert run(model.set_prompt(prompt="p", metadata="")) is None
+    assert refusal(model).command == "set_prompt"
+
+
+def test_the_continuity_snapshot_carries_the_prompt_and_canvas(continuity_model):
+    run(continuity_model.set_prompt(prompt="a lighthouse", metadata=""))
+    continuity_model._channel_running = True
+    state = run(continuity_model.get_state())
+    assert state.continuity is True
+    assert state.prompt == "a lighthouse"
+    assert (state.height, state.width) == (640, 1152)
+    assert "set_prompt" in state.valid_commands
+    assert "enqueue" not in state.valid_commands
+
+
+def test_stop_needs_a_running_take(continuity_model):
+    assert run(continuity_model.stop()) is None
+    assert refusal(continuity_model).command == "stop"
+    continuity_model._channel_running = True
+    run(continuity_model.stop())
+    assert continuity_model._stop_channel is True
+
+
+def test_stop_ends_the_take_and_drops_the_prompt(continuity_model):
+    # Stop must clear the held prompt, not just cut the current clip: otherwise
+    # the run loop re-anchors a fresh take on the still-held prompt and the
+    # stream never actually stops.
+    run(continuity_model.set_prompt(prompt="a harbour at dusk", metadata="m"))
+    continuity_model._channel_running = True
+    run(continuity_model.stop())
+    assert continuity_model._stop_channel is True
+    assert continuity_model._prompt == ""
+    assert continuity_model._prompt_metadata == ""
+
+
+def test_reset_drops_the_held_prompt(continuity_model):
+    run(continuity_model.set_prompt(prompt="a river", metadata=""))
+    continuity_model._channel_running = True
+    reply = run(continuity_model.reset())
+    assert reply.was_playing is True
+    assert continuity_model._prompt == ""
+    assert continuity_model._stop_channel is True
+
+
+def test_the_canvas_is_locked_while_a_prompt_drives_the_take(continuity_model):
+    run(continuity_model.set_prompt(prompt="a dune", metadata=""))
+    assert run(continuity_model.set_canvas(aspect="1:1")) is None
+    assert refusal(continuity_model).command == "set_canvas"
+    # Cleared, the canvas is selectable again.
+    run(continuity_model.reset())
+    reply = run(continuity_model.set_canvas(aspect="1:1"))
+    assert (reply.height, reply.width) == (640, 640)
+
+
+# -- runtime mode toggle (set_continuity) -----------------------------------
+
+
+def test_set_continuity_switches_an_idle_take_to_the_hard_cut_queue(continuity_model):
+    """An idle continuity session flips to the queue: length + surface follow."""
+    assert continuity_model._continuity is True
+    reply = run(continuity_model.set_continuity(enabled=False))
+    assert reply.continuity is False
+    assert continuity_model._continuity is False
+    # The queue's default length replaces the continuity length.
+    assert continuity_model._clip_frames == continuity_model.config.clip_frames
+    state = run(continuity_model.get_state())
+    assert state.continuity is False
+    assert "enqueue" in state.valid_commands
+    assert "set_prompt" not in state.valid_commands
+    # And the queue commands now actually run instead of being refused.
+    assert run(continuity_model.enqueue(prompt="a", metadata="")) is not None
+
+
+def test_set_continuity_switches_an_idle_queue_to_continuity(model):
+    """An idle queue session flips to the take: length + surface follow."""
+    assert model._continuity is False
+    reply = run(model.set_continuity(enabled=True))
+    assert reply.continuity is True
+    assert model._continuity is True
+    assert model._clip_frames == model.config.continuity_clip_frames
+    state = run(model.get_state())
+    assert state.continuity is True
+    assert "set_prompt" in state.valid_commands
+    assert "enqueue" not in state.valid_commands
+    # set_prompt, refused a moment ago in the queue, now drives the stream.
+    assert run(model.set_prompt(prompt="a misty forest", metadata="")) is not None
+
+
+def test_set_continuity_is_refused_while_a_take_runs(continuity_model):
+    run(continuity_model.set_prompt(prompt="a harbour", metadata=""))
+    continuity_model._channel_running = True
+    assert run(continuity_model.set_continuity(enabled=False)) is None
+    assert refusal(continuity_model).command == "set_continuity"
+    # The mode is unchanged: the switch never straddles a running take.
+    assert continuity_model._continuity is True
+
+
+def test_set_continuity_is_refused_while_clips_are_queued(model):
+    run(model.enqueue(prompt="a", metadata=""))
+    assert run(model.set_continuity(enabled=True)) is None
+    assert refusal(model).command == "set_continuity"
+    assert model._continuity is False
+
+
+def test_set_continuity_is_an_idempotent_ack_in_the_same_mode(continuity_model):
+    """Requesting the mode already in force is a clean no-op, not a refusal."""
+    reply = run(continuity_model.set_continuity(enabled=True))
+    assert reply.continuity is True
+    assert continuity_model._continuity is True
+    assert refusal(continuity_model) is None
+
+
+def test_the_queue_serve_loop_hands_off_when_the_mode_flips(model):
+    """`set_continuity(true)` while idle lets `_serve` return so run() re-dispatches."""
+
+    async def main():
+        model.connected.set()
+        model._continuity = True
+        # If the guard did not pick up the flip, this would spin until timeout.
+        await asyncio.wait_for(model._serve(), timeout=1.0)
+
+    asyncio.run(main())
+
+
+def test_the_continuity_serve_loop_hands_off_when_the_mode_flips(continuity_model):
+    """`set_continuity(false)` while idle lets `_serve_continuity` return likewise."""
+
+    async def main():
+        continuity_model.connected.set()
+        continuity_model._continuity = False
+        await asyncio.wait_for(continuity_model._serve_continuity(), timeout=1.0)
+
+    asyncio.run(main())
+

--- a/skills/reactor-fast-h3-model/SKILL.md
+++ b/skills/reactor-fast-h3-model/SKILL.md
@@ -5,11 +5,29 @@ description: Full context for the fast-h3 model in this repo — what FastH3/Min
 
 # The fast-h3 model: full working context
 
-`fast-h3/` turns the FastH3 video model into a **clip queue with a player**,
-served by the open-source [Reactor Runtime](https://github.com/reactor-team/reactor-runtime).
-Clients enqueue prompt-driven generations, the model builds them ahead of
-time, and nothing reaches the media tracks until asked (or autoplay is on).
-This file is the context a new agent needs; the per-file detail lives in
+`fast-h3/` serves the FastH3 video model in one of **two modes**, defaulted by
+`inference.continuity` and switchable per-session at runtime via `set_continuity`
+(while idle), over the open-source
+[Reactor Runtime](https://github.com/reactor-team/reactor-runtime):
+
+- **Continuity (default on)** — one continuous take. `set_prompt` holds a prompt
+  and the model builds clips back to back forever, each after the first
+  FL2VA-anchored on the previous clip's last frame, its exposure locked to the
+  opener's, every boundary crossfaded in linear light. One prompt → one
+  uninterrupted stream until `stop` or a new `set_prompt`. Shipped at the 640
+  resolution tier, where a 5.167 s clip builds in ~3.3 s on 8 B200s — under the
+  playout window, so the chain never starves.
+- **Queue (off)** — a **clip queue with a player**: clients `enqueue`
+  prompt-driven generations, the model builds them ahead of time, nothing
+  reaches the tracks until `play` (or autoplay), hard cut between clips. The
+  streaming client drives this mode.
+
+Both live in one `FastH3` class with disjoint command surfaces
+(`state_update.valid_commands` names the live set). The mode is a per-session
+flag (`self._continuity`, seeded from the config): `set_continuity` flips it
+while the session is idle and `run()`/`_serve*` re-dispatch to the other loop,
+so a client picks hard cuts or continuity without a redeploy. This file is the
+context a new agent needs; the per-file detail lives in
 [`fast-h3/README.md`](../../fast-h3/README.md) and the code's own docstrings.
 
 ## 1. The underlying model
@@ -21,11 +39,15 @@ to **four transformer forwards**, plus VSA-H3 sparse video attention at 90%
 sparsity. Facts that shape everything downstream:
 
 - **Fully bidirectional, not autoregressive.** One denoise covers the whole
-  clip's token sequence at once. There is no KV cache, no rollout, no
-  continuation: every clip is an independent sample, and clip boundaries are
-  hard cuts in both picture and sound. Only text-to-audio-video was
-  distilled (the base model's first/last-frame and reference conditioning
-  were not).
+  clip's token sequence at once — no KV cache, no rollout. Every clip is an
+  independent sample; the queue mode leaves the boundaries as hard cuts. Only
+  text-to-audio-video was distilled (the base model's first/last-frame and
+  reference conditioning were not), so continuity's FL2VA anchoring is an
+  **undistilled** carry: it seeds the next clip with the previous last frame and
+  the seam crossfade dissolves the boundary, but it is a best-effort continuation
+  the checkpoint was not trained for, not an identity lock. Exposure is held
+  stable across the chain by a float64-mean colour lock (a float32 clip-mean
+  saturates the mantissa at production sizes and blows highlights to white).
 - **One packed sequence, video + audio + text.** The H3-Omni-Transformer is a
   33B dense single-stream DiT over a packed multimodal sequence with 3D
   RoPE; audio is generated jointly (native stereo, decoded by a separate


### PR DESCRIPTION
…640 canvas + runtime toggle

Adds a second, config-selectable run mode to the fast-h3 model: a single continuous FL2VA-chained take alongside the existing hard-cut clip queue, shipped as the default at a new 640 resolution tier that is gap-free on 8 B200s.

Continuity mode
- `set_prompt` holds one prompt; the model builds clips back to back forever, each after clip 0 FL2VA-anchored on the previous clip's colour-matched last frame, every boundary crossfaded in linear light — one prompt, one uninterrupted stream until `stop` or a new `set_prompt`. No clip cap, no re-prompting. `_serve_continuity`/`_run_continuity_take` build one clip ahead so the chain never starves.

Correctness fixes
- Exposure-lock colour match now reduces the clip mean in float64. A float32 reduction over a full-size clip (~1e8 samples) saturated the mantissa (mean collapsed ~33 vs true ~124), shoving every continuation ~90 levels brighter and clipping ~19% of pixels to white. float64 CPU fallback + a guarded GPU fast-path (int64/float64 reduction), verified bit-close.
- Seam blend is a GPU linear-light complementary crossfade (CPU fallback, verified bit-close) relocated off the emit metronome onto the generation worker, which is what keeps 640 gap-free.

Selectable resolution
- `inference.canvas_short_edge` makes the short edge a real config knob (multiple of 32, 256–768); every aspect resolves at that tier. 640 is now a first-class canvas plumbed end-to-end (clip_plan geometry, seam frames, backend, playout); 768 stays selectable. Shipping default: continuity + 640.

Runtime toggle
- `set_continuity(bool)` flips a session between the continuous take and the hard-cut queue at runtime, idle-gated (nothing playing/queued, no prompt held) so no clip or take straddles the switch. Config sets the starting mode; `reset` keeps the chosen one. Surfaced in session_rules, StateUpdate, and a ContinuityAccepted ack. The queue/hard-cut path is unchanged when off.

Verified on the real _run_channel adapter at 640 over 20+ clips: gap-free with ~0.5 s margin (0 emit stalls), exposure locked (0% white-clip, no ratchet), seams smooth, set_prompt/stop/reset and the runtime toggle all correct; hard-cut path untouched. 533 tests pass.