### PR TITLE
feat(fast-h3): image-to-video — seed a continuity take from an upload…

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -148,7 +148,9 @@ Director being the queues' only writer (viewer worker, idle filler, and
   `fasth3_backend.py` the FastVideo engine + worker thread, and continuity's
   post-decode pipeline that runs on it (FL2VA anchor, GPU exposure lock, GPU
   seam blend); `fasth3_seam.py` the pure-numpy exposure lock and linear-light
-  crossfade (no torch); `fasth3_assets.py` config parsing and weights validation
+  crossfade (no torch); `fasth3_image.py` decoding a `set_seed_image` upload
+  (a still, image-to-video) to the seed frame that anchors clip 0;
+  `fasth3_assets.py` config parsing and weights validation
   (the only reader of `fasth3.yaml`); `fasth3_clip_plan.py` pure clip geometry
   and resolution tiers; `fasth3_session_rules.py` which commands each state
   accepts, per mode. New code goes in the seam that owns it. No `__init__.py` —

--- a/fast-h3/README.md
+++ b/fast-h3/README.md
@@ -164,7 +164,7 @@ size in force.
 ## Commands
 
 The two modes offer disjoint surfaces; `state_update.valid_commands` names the
-live set. `set_prompt` is continuity-only;
+live set. `set_prompt`/`set_seed_image` are continuity-only;
 `enqueue`/`play`/`move`/`pop`/`get_queue`/`set_autoplay` are queue-only. The rest
 are shared. `set_continuity` is the runtime toggle between the two — offered
 while the session is idle so a client picks the mode without a config change.
@@ -172,6 +172,7 @@ while the session is idle so a client picks the mode without a config change.
 | Command | Parameters | Effect | Rejected when |
 |---|---|---|---|
 | `set_prompt` | `prompt` (≤ 800 chars), `metadata` (≤ 2000 chars) | **Continuity mode.** Sets the prompt the continuous take follows; the first starts the take, a later one re-anchors it. Replies `prompt_accepted`. | empty prompt, or the model runs the queue |
+| `set_seed_image` | `image` (uploaded still) | **Continuity mode.** Seeds the next take (image-to-video): the still becomes clip 0's opening moment and the stream animates forward. Fitted to the canvas, held until `set_prompt` starts the take, used once, dropped by `reset`/`stop`. Replies `seed_image_accepted`. To continue from a video, send the frame you want as an image. | a take is already running, a video or undecodable/unsupported file, or the model runs the queue |
 | `enqueue` | `prompt` (≤ 800 chars), `metadata` (≤ 2000 chars), `seed` (optional, ≥ 0), `seconds` (optional, 5.167–14.375), `position` (optional, ≥ 0) | **Queue mode.** Enters the generation queue at `position` (0 = next build; omitted = the back); replies `clip_queued` with the full `ClipInfo`. Without a seed the session's advancing default is used; without `seconds` the session's default length. | generation queue full, empty prompt, or the model runs continuity |
 | `move` | `clip_id` (UUID), `position` (≥ 0) | Repositions the clip within whichever queue holds it; 0 = front, clamped to the back. Replies `clip_moved` with the queue's name and the landing position. | unknown or missing id |
 | `play` | `clip_id` (optional UUID) | Streams the playout queue's front clip, or the named one. Emits `clip_started` as frames begin. | already playing, unknown id, clip still generating |
@@ -209,6 +210,7 @@ A rejected command has no effect and is answered by a broadcast
 | `canvas_accepted` | the caller | Reply to `set_canvas`. Carries the exact pixel size. |
 | `prompt_accepted` | the caller | Reply to `set_prompt` (continuity). Carries the prompt the take now follows. |
 | `continuity_accepted` | the caller | Reply to `set_continuity`. Carries the mode now in force. |
+| `seed_image_accepted` | the caller | Reply to `set_seed_image`. Carries the seed frame's fitted size. |
 | `session_reset` | the caller | Reply to `reset`. Says how many clips were dropped. |
 
 ## Session lifecycle
@@ -286,6 +288,18 @@ set and an audience is connected. The FL2VA and Ref2VA conditioning this uses
 were not distilled into the checkpoint, so the anchored continuation is a
 best-effort carry rather than a trained one — good enough to dissolve a seam,
 not a guaranteed identity lock.
+
+The take can also be **seeded from an uploaded image** (`set_seed_image`,
+[`fasth3_image.py`](./fasth3_image.py)): a still becomes clip 0's anchor and the
+stream animates forward from it — image-to-video. The seed is fed down the same
+FL2VA anchor path a self-generated clip uses, so the generator VAE-encodes it for
+conditioning and VAE-decodes the result; an off-distribution source (a phone
+photo, a different colour space) is pulled onto the model's own look by that
+round-trip, and clip 0's exposure lock is taken from the on-distribution decode,
+not the raw upload. To *continue from a video*, a client extracts the frame it
+wants and sends that as the image — the same anchor logic, without a video
+decoder in this process. Whole-video restyling (Ref2VA/LV2V) is **not** possible
+— that conditioning was never distilled into this checkpoint.
 
 **Queue (`continuity: false`)** is the clip-at-a-time channel described above:
 every clip generated independently, `enqueue`d and `play`ed, the stream holding
@@ -373,6 +387,7 @@ tree arrives through `requirements.txt` and an upgrade is a one-line bump.
 | `fasth3_assets.py` | Config parsing and weights-bundle validation |
 | `fasth3_clip_plan.py` | Clip geometry: valid lengths, frame counts, canvases, resolution tiers |
 | `fasth3_seam.py` | Continuity's pure-numpy exposure lock and linear-light seam crossfade (no torch) |
+| `fasth3_image.py` | Decode a `set_seed_image` upload (a still) to a seed frame — pure, no torch |
 | `fasth3_session_rules.py` | Which commands each session state accepts, per mode |
 | `fasth3.yaml` | `inference:` the recipe, queue size and warm-up plan, `runtime:` weight layout and engine shape |
 | `reactor.yaml` | The manifest: identity, version, resources, runtime, image build |

--- a/fast-h3/fasth3.py
+++ b/fast-h3/fasth3.py
@@ -38,6 +38,7 @@ from reactor_runtime import (
     ClientInfo,
     InputField,
     ReactorModel,
+    UploadedFile,
     connected,
     event,
     get_weights_path,
@@ -71,6 +72,7 @@ from fasth3_types import (
     PromptAccepted,
     QueueUpdate,
     SeedAccepted,
+    SeedImageAccepted,
     SessionReset,
     StateUpdate,
 )
@@ -184,6 +186,12 @@ class FastH3(ReactorModel):
         self._prompt_epoch: int = 0
         self._channel_running: bool = False
         self._stop_channel: bool = False
+        # An optional seed frame (uint8 RGB HWC) from an uploaded image
+        # (`set_seed_image`): when set, the next take's clip 0 opens FL2VA-anchored
+        # on it (image-to-video) instead of from text alone, and is consumed once
+        # when that take starts. None is the plain text-to-video opener.
+        # Continuity only.
+        self._seed_anchor = None
 
         # The two queues, and the playout lifecycle around them: builds
         # consume `_generation` from the front and finished clips join the
@@ -679,6 +687,7 @@ class FastH3(ReactorModel):
         )
         self._prompt = ""
         self._prompt_metadata = ""
+        self._seed_anchor = None
         await self._send_state_update()
         return ContinuityAccepted(continuity=enabled)
 
@@ -739,6 +748,75 @@ class FastH3(ReactorModel):
         return PromptAccepted(prompt=prompt)
 
     @event(
+        name="set_seed_image",
+        description=(
+            "Seed the continuous take from an uploaded image (continuity mode "
+            "only) — image-to-video: the still becomes the take's opening "
+            "moment and the stream animates forward from it. The seed conditions "
+            "clip 0 the same way the take chains its own clips, and the generator "
+            "round-trips it through the model's VAE so an off-distribution source "
+            "(a phone photo, a different colour space) is pulled onto the model's "
+            "own look. The seed is held until the take starts (`set_prompt`) and "
+            "is used once; `reset` or `stop` drops it. Send it before "
+            "`set_prompt`. To continue from a video, extract the frame you want "
+            "and send it here as an image. Emits `seed_image_accepted` and "
+            "`state_update`, or `command_error` when the model runs the clip "
+            "queue, a take is already running, or the file is not a decodable "
+            "image."
+        ),
+    )
+    async def set_seed_image(
+        self,
+        image: UploadedFile = InputField(
+            moderate=True,
+            description=(
+                "A still image to animate from. Common formats decode; the frame "
+                "is fitted to the session canvas."
+            ),
+        ),
+    ) -> SeedImageAccepted:
+        """Decode an uploaded image into the seed frame for the next take."""
+        if not self._continuity:
+            await self._refuse(
+                "set_seed_image",
+                "`set_seed_image` seeds a continuity take; this stream uses the "
+                "clip queue.",
+            )
+            return None
+        if self._channel_running:
+            await self._refuse(
+                "set_seed_image",
+                "A take is already running; `stop` it before seeding a new one.",
+            )
+            return None
+
+        import numpy as np
+        from PIL import Image
+
+        import fasth3_image as image_decode
+
+        try:
+            frame = image_decode.decode_seed_frame(
+                image.data, image.mime_type, image.name
+            )
+        except image_decode.SeedDecodeError as error:
+            await self._refuse("set_seed_image", str(error))
+            return None
+
+        # Fit the seed to the session canvas so the anchor (and its exposure
+        # reference) match the frames the take will produce. The generator would
+        # resize anyway; doing it here keeps the whole path at one resolution.
+        height, width = self._canvas()
+        anchor = Image.fromarray(frame).resize(
+            (width, height), Image.Resampling.LANCZOS
+        )
+        self._seed_anchor = np.asarray(anchor, dtype=np.uint8)
+        await self._send_state_update()
+        return SeedImageAccepted(
+            filename=image.name, width=width, height=height
+        )
+
+    @event(
         name="stop",
         description=(
             "Cut what is playing to black within a fraction of a second. In "
@@ -765,6 +843,7 @@ class FastH3(ReactorModel):
             self._stop_channel = True
             self._prompt = ""
             self._prompt_metadata = ""
+            self._seed_anchor = None
             return
         if self._current_clip() is None:
             await self._refuse("stop", "No clip is playing.")
@@ -951,6 +1030,7 @@ class FastH3(ReactorModel):
             self._prompt = ""
             self._prompt_metadata = ""
             self._prompt_epoch += 1
+            self._seed_anchor = None
             self._clip_frames = self.config.continuity_clip_frames
             self._seed = self.config.seed
             self._aspect = self.config.aspect
@@ -1067,11 +1147,17 @@ class FastH3(ReactorModel):
         prompt = self._prompt
         take_epoch = self._prompt_epoch
         started_at = time.monotonic()
-        # Clip 0 opens plain: text-to-video, no first-frame anchor. The take
-        # then chains every later clip on its own colour-matched last frame.
+        # A seed from `set_seed_image` opens clip 0 FL2VA-anchored on the
+        # uploaded still (image-to-video); the generator VAE round-trips it onto
+        # the model's distribution. Consumed once — the take chains its own
+        # frames from clip 1 on. No seed is the plain text-to-video opener.
+        seed_anchor = None
+        if self._seed_anchor is not None:
+            seed_anchor = Image.fromarray(self._seed_anchor)
+            self._seed_anchor = None
         job = self.backend.submit_continuity(
             index=0, frames=frames, prompt=prompt, seed=self._seed,
-            height=height, width=width, anchor=None, seam_frames=seam_frames,
+            height=height, width=width, anchor=seed_anchor, seam_frames=seam_frames,
         )
         await self._send_state_update()
 

--- a/fast-h3/fasth3_image.py
+++ b/fast-h3/fasth3_image.py
@@ -1,0 +1,123 @@
+"""Decode a client-uploaded seed image — pure, no torch, no GPU.
+
+Off by default. When ``inference.continuity`` is set, the take can be *seeded*
+from a still image the client uploads (`set_seed_image`): image-to-video, the
+still becomes a moving take. This module turns those raw bytes into the one
+thing the generator needs — the **seed frame**, as ``uint8`` RGB ``[h, w, 3]``
+— and nothing else, so it can be tested on any machine without a GPU or the
+inference stack. ``fasth3.py`` imports it lazily, so rendering the schema needs
+no Pillow.
+
+The seed frame is fed to clip 0 as the FL2VA first-frame condition, exactly the
+anchor path a self-generated clip already uses. The generator VAE-encodes it for
+conditioning and VAE-decodes the result, so an off-distribution external frame
+(a phone photo, a different colour space) is pulled onto the model's own decode
+distribution by generation itself — clip 0's opening frame is
+``decode(encode(seed))``, not the raw upload.
+
+Video is deliberately not accepted: a client that wants to *continue from* a
+video extracts the frame it wants and sends that as an image, which is the same
+anchor logic without a decoder for every container in this process. The frame
+comes back as ``uint8`` RGB ``[h, w, 3]`` at the image's own resolution; the
+caller resizes to the session canvas (the generator would anyway, but resizing
+here keeps the anchor and any reference consistent).
+"""
+
+from __future__ import annotations
+
+import io
+
+import numpy as np
+
+__all__ = [
+    "MAX_SEED_BYTES",
+    "SeedDecodeError",
+    "decode_seed_frame",
+]
+
+# A generous ceiling for a single still. Guards against a decompression bomb or
+# an accidental multi-GB upload wedging the worker. The runtime also bounds the
+# upload; this is defence in depth.
+MAX_SEED_BYTES = 64 * 1024 * 1024
+
+# Pillow's own guard against decompression-bomb images, in pixels. 768x1344 is
+# ~1M px; 64M px is ~60x the largest canvas, comfortably above any real still.
+_MAX_IMAGE_PIXELS = 64 * 1024 * 1024
+
+# Containers a client might send hoping to continue from a video. Rejected with
+# a message that points at the supported path (send a frame as an image).
+_VIDEO_EXTENSIONS = frozenset(
+    {"mp4", "mov", "m4v", "webm", "mkv", "avi", "gif", "mpg", "mpeg", "ts"}
+)
+
+
+class SeedDecodeError(ValueError):
+    """Raised when an upload cannot be turned into a seed frame.
+
+    A ``ValueError`` subclass so callers can catch either; the message is
+    client-safe (it never leaks a path or a stack) and is meant to be handed
+    straight back as a command refusal.
+    """
+
+
+def decode_seed_frame(
+    data: bytes, mime_type: str = "", name: str = ""
+) -> np.ndarray:
+    """Turn an uploaded still into one seed frame — ``uint8`` RGB ``[h, w, 3]``.
+
+    Raises :class:`SeedDecodeError` on anything the caller should refuse: an
+    empty upload, an oversized one, a video (unsupported — send a frame as an
+    image), or a corrupt/unreadable file. Never raises anything else, so a bad
+    upload is a clean refusal and never a worker crash.
+    """
+    if not data:
+        raise SeedDecodeError("The upload is empty.")
+    if len(data) > MAX_SEED_BYTES:
+        raise SeedDecodeError(
+            f"The upload is {len(data) // (1024 * 1024)} MB; the limit is "
+            f"{MAX_SEED_BYTES // (1024 * 1024)} MB for a seed image."
+        )
+    _reject_video(mime_type, name)
+    return _decode_image(data)
+
+
+# ------------------------------------------------------------------ internals
+
+
+def _reject_video(mime_type: str, name: str) -> None:
+    """Refuse a video upload early, with a message that names the supported path."""
+    mime = (mime_type or "").strip().lower()
+    ext = name.rsplit(".", 1)[-1].lower() if "." in name else ""
+    if mime.startswith("video/") or ext in _VIDEO_EXTENSIONS:
+        raise SeedDecodeError(
+            "Video is not accepted as a seed; extract the frame you want to "
+            "start from and send it as an image."
+        )
+
+
+def _decode_image(data: bytes) -> np.ndarray:
+    """Decode a still to ``uint8`` RGB ``[h, w, 3]`` with PIL."""
+    from PIL import Image
+
+    prev_limit = Image.MAX_IMAGE_PIXELS
+    Image.MAX_IMAGE_PIXELS = _MAX_IMAGE_PIXELS
+    try:
+        with Image.open(io.BytesIO(data)) as image:
+            frame = np.asarray(image.convert("RGB"), dtype=np.uint8)
+    except SeedDecodeError:
+        raise
+    except Exception as error:  # noqa: BLE001 — any decode failure is a refusal
+        raise SeedDecodeError(f"The image could not be decoded ({error}).") from None
+    finally:
+        Image.MAX_IMAGE_PIXELS = prev_limit
+
+    return _validate_frame(frame)
+
+
+def _validate_frame(frame: np.ndarray) -> np.ndarray:
+    """Guarantee the caller gets a contiguous ``uint8`` RGB ``[h, w, 3]`` frame."""
+    if frame.ndim != 3 or frame.shape[2] != 3 or frame.shape[0] < 1 or frame.shape[1] < 1:
+        raise SeedDecodeError("The decoded image is not a colour image.")
+    if frame.dtype != np.uint8:
+        frame = np.clip(frame, 0, 255).astype(np.uint8)
+    return np.ascontiguousarray(frame)

--- a/fast-h3/fasth3_session_rules.py
+++ b/fast-h3/fasth3_session_rules.py
@@ -43,11 +43,14 @@ def valid_commands(
         commands = ["get_state", "reset", "set_prompt", "set_seed"]
         if playing:
             commands.append("stop")
-        elif not prompt_set:
-            # The canvas is still free until a prompt fixes it, and while idle
-            # the client may switch this session to the hard-cut queue.
-            commands.append("set_canvas")
-            commands.append("set_continuity")
+        else:
+            # Before the take runs, the client can seed it from an uploaded
+            # image (I2V); the canvas is still free until a prompt fixes it.
+            commands.append("set_seed_image")
+            if not prompt_set:
+                commands.append("set_canvas")
+                # Idle: the client may switch this session to the hard-cut queue.
+                commands.append("set_continuity")
         return sorted(commands)
 
     commands = list(_ALWAYS)

--- a/fast-h3/fasth3_types.py
+++ b/fast-h3/fasth3_types.py
@@ -320,6 +320,19 @@ class PromptAccepted(ModelMessage):
     prompt: str = MessageField(description="The prompt the stream now follows.")
 
 
+class SeedImageAccepted(ModelMessage):
+    """Emitted when `set_seed_image` accepts an uploaded still (continuity, I2V).
+
+    The take's next clip 0 opens from this image instead of from text alone: the
+    still is animated forward. The seed is held until the take starts
+    (`set_prompt`), or dropped by `reset`/`stop`.
+    """
+
+    filename: str = MessageField(description="The uploaded file's name, echoed back.")
+    width: int = MessageField(description="Width of the seed frame after fitting the canvas.")
+    height: int = MessageField(description="Height of the seed frame after fitting the canvas.")
+
+
 class CanvasAccepted(ModelMessage):
     """Emitted when `set_canvas` is accepted."""
 

--- a/fast-h3/reactor.yaml
+++ b/fast-h3/reactor.yaml
@@ -5,12 +5,13 @@ model:
   name: fast-h3
   # Bare semver, no `v` prefix — the platform's release tag format; the
   # registration validator refuses a prefixed one.
-  version: 0.6.0
+  version: 0.6.1
   description: |
     Generate video with synchronized audio from MiniMax-H3 (35B), distilled by
     FastVideo to four transformer forwards with 90% sparse video attention. Two
     modes: a continuous single-prompt take that chains and crossfades clips into
-    one uninterrupted stream (`set_prompt`), and a clip queue that builds
+    one uninterrupted stream (`set_prompt`), optionally seeded from an uploaded
+    image (`set_seed_image`, image-to-video), and a clip queue that builds
     enqueued prompts in order and plays any built clip on demand
     (`enqueue`/`play`), holding on black in between.
   # Eight Blackwell GPUs: the count that builds faster than the stream plays

--- a/fast-h3/tests/test_fasth3.py
+++ b/fast-h3/tests/test_fasth3.py
@@ -1054,6 +1054,7 @@ EXPECTED_COMMANDS = {
     "set_continuity": "ContinuityAccepted",
     "set_prompt": "PromptAccepted",
     "set_seed": "SeedAccepted",
+    "set_seed_image": "SeedImageAccepted",
     "stop": None,
 }
 
@@ -1074,6 +1075,7 @@ EXPECTED_MESSAGES = {
     "prompt_accepted",
     "queue_update",
     "seed_accepted",
+    "seed_image_accepted",
     "session_reset",
     "state_update",
 }
@@ -1082,7 +1084,7 @@ EXPECTED_MESSAGES = {
 # name the message a client will actually receive.
 EXPECTED_REJECTIONS = (
     "enqueue", "move", "play", "pop", "stop", "set_canvas", "set_prompt",
-    "set_continuity",
+    "set_seed_image", "set_continuity",
 )
 
 # The struct every clip-referencing message embeds, and its JSON types.
@@ -1492,6 +1494,8 @@ def test_continuity_offers_the_prompt_surface_not_the_queue():
         playout_queued=0, continuity=True, prompt_set=False,
     )
     assert "set_prompt" in idle and "set_canvas" in idle
+    # The take can be seeded from an uploaded image (I2V) before it starts.
+    assert "set_seed_image" in idle
     # Idle: the session may be switched to the hard-cut queue.
     assert "set_continuity" in idle
     assert not ({"enqueue", "play", "move", "pop", "get_queue", "set_autoplay"} & set(idle))
@@ -1501,9 +1505,10 @@ def test_continuity_offers_the_prompt_surface_not_the_queue():
         playout_queued=0, continuity=True, prompt_set=True,
     )
     assert "stop" in running
-    # The canvas is fixed and the mode can no longer be switched once the
-    # take runs.
+    # The canvas is fixed, a seed can no longer be set, and the mode can no
+    # longer be switched once the take runs.
     assert "set_canvas" not in running
+    assert "set_seed_image" not in running
     assert "set_continuity" not in running
 
 
@@ -1777,3 +1782,138 @@ def test_the_continuity_serve_loop_hands_off_when_the_mode_flips(continuity_mode
 
     asyncio.run(main())
 
+
+# -- seeding the take from an uploaded image, I2V (PR#2) --------------------
+#
+# The pure decoder is exercised on real bytes; the handler is exercised with a
+# constructed UploadedFile, so both the decode and the seed lifecycle run on a
+# laptop without a GPU. Video is deliberately unsupported: a client extracts the
+# frame it wants and sends it as an image.
+
+
+def _png_bytes(rgb: tuple[int, int, int], size=(48, 64)) -> bytes:
+    import io
+
+    from PIL import Image
+
+    buf = io.BytesIO()
+    Image.new("RGB", size, rgb).save(buf, format="PNG")
+    return buf.getvalue()
+
+
+def _upload(data: bytes, mime_type: str, name: str):
+    from reactor_runtime import UploadedFile
+
+    return UploadedFile(name=name, mime_type=mime_type, data=data)
+
+
+def test_the_decoder_reads_a_still_image():
+    import fasth3_image as image
+
+    frame = image.decode_seed_frame(_png_bytes((10, 120, 240)), "image/png", "s.png")
+    # PIL size is (width, height); the array comes back (height, width, 3).
+    assert frame.shape == (64, 48, 3) and frame.dtype == np.uint8
+
+
+def test_the_decoder_rejects_video_with_a_pointer_to_the_image_path():
+    import fasth3_image as image
+
+    # A video is refused before any decode, by mime and by extension, with a
+    # message that names the supported path (send a frame as an image).
+    for mime, name in [("video/mp4", "clip.mp4"), ("", "clip.mov")]:
+        with pytest.raises(image.SeedDecodeError, match="as an image"):
+            image.decode_seed_frame(b"\x00\x00\x00\x18ftyp", mime, name)
+
+
+def test_the_decoder_refuses_junk():
+    import fasth3_image as image
+
+    for data, mime, name in [
+        (b"", "image/png", "a.png"),
+        (b"not-an-image", "image/png", "a.png"),
+        (b"hello", "text/plain", "a.txt"),
+    ]:
+        with pytest.raises(image.SeedDecodeError):
+            image.decode_seed_frame(data, mime, name)
+
+
+def test_set_seed_image_fits_an_image_to_the_canvas(continuity_model):
+    reply = run(
+        continuity_model.set_seed_image(
+            image=_upload(_png_bytes((200, 30, 30)), "image/png", "still.png")
+        )
+    )
+    assert reply.filename == "still.png"
+    # Fitted to the 640 tier's 16:9 canvas the fixture loads.
+    assert (reply.height, reply.width) == continuity_model._canvas()
+    seed = continuity_model._seed_anchor
+    assert seed is not None and seed.dtype == np.uint8
+    assert seed.shape == (reply.height, reply.width, 3)
+
+
+def test_set_seed_image_refuses_a_video_upload(continuity_model):
+    assert (
+        run(
+            continuity_model.set_seed_image(
+                image=_upload(b"\x00\x00\x00\x18ftyp", "video/mp4", "clip.mp4")
+            )
+        )
+        is None
+    )
+    assert refusal(continuity_model).command == "set_seed_image"
+    assert continuity_model._seed_anchor is None
+
+
+def test_set_seed_image_refuses_a_non_image_upload(continuity_model):
+    assert (
+        run(
+            continuity_model.set_seed_image(
+                image=_upload(b"junk", "application/pdf", "a.pdf")
+            )
+        )
+        is None
+    )
+    assert refusal(continuity_model).command == "set_seed_image"
+    assert continuity_model._seed_anchor is None
+
+
+def test_set_seed_image_is_refused_while_a_take_runs(continuity_model):
+    continuity_model._channel_running = True
+    assert (
+        run(
+            continuity_model.set_seed_image(
+                image=_upload(_png_bytes((1, 2, 3)), "image/png", "s.png")
+            )
+        )
+        is None
+    )
+    assert refusal(continuity_model).command == "set_seed_image"
+
+
+def test_set_seed_image_is_refused_in_the_queue_mode(model):
+    assert (
+        run(model.set_seed_image(image=_upload(_png_bytes((1, 2, 3)), "image/png", "s.png")))
+        is None
+    )
+    assert refusal(model).command == "set_seed_image"
+
+
+def test_reset_and_stop_drop_the_seed(continuity_model):
+    run(
+        continuity_model.set_seed_image(
+            image=_upload(_png_bytes((9, 9, 9)), "image/png", "s.png")
+        )
+    )
+    assert continuity_model._seed_anchor is not None
+    run(continuity_model.reset())
+    assert continuity_model._seed_anchor is None
+
+    # And a stop mid-take clears any seed too.
+    run(
+        continuity_model.set_seed_image(
+            image=_upload(_png_bytes((9, 9, 9)), "image/png", "s.png")
+        )
+    )
+    continuity_model._channel_running = True
+    run(continuity_model.stop())
+    assert continuity_model._seed_anchor is None

--- a/skills/reactor-fast-h3-model/SKILL.md
+++ b/skills/reactor-fast-h3-model/SKILL.md
@@ -16,7 +16,11 @@ description: Full context for the fast-h3 model in this repo — what FastH3/Min
   opener's, every boundary crossfaded in linear light. One prompt → one
   uninterrupted stream until `stop` or a new `set_prompt`. Shipped at the 640
   resolution tier, where a 5.167 s clip builds in ~3.3 s on 8 B200s — under the
-  playout window, so the chain never starves.
+  playout window, so the chain never starves. The take can be **seeded** from an
+  uploaded image (`set_seed_image`, image-to-video); the seed rides the same
+  FL2VA anchor path, so the generator's VAE round-trips it onto the model's
+  distribution. (To continue from a video, a client sends the frame it wants as
+  an image — the same anchor path, no in-process video decoder.)
 - **Queue (off)** — a **clip queue with a player**: clients `enqueue`
   prompt-driven generations, the model builds them ahead of time, nothing
   reaches the tracks until `play` (or autoplay), hard cut between clips. The


### PR DESCRIPTION
…ed still

Stacked on the continuity branch. Lets a client open the continuous take from an uploaded image instead of from text alone (I2V): the still becomes clip 0's FL2VA anchor and the stream animates forward from it, then chains its own frames.

- `set_seed_image(image)` decodes the upload, fits it to the session canvas, and holds it as clip 0's anchor until `set_prompt` starts the take (used once; dropped by `reset`/`stop`). Continuity-only; refused in the queue mode, while a take already runs, or on an undecodable file. Replies `seed_image_accepted`.
- The seed rides the same FL2VA anchor path a self-generated clip uses, so the generator VAE-encodes it for conditioning and VAE-decodes the result: an off-distribution source (a phone photo, a different colour space, even a stylised cartoon) is pulled onto the model's own decode distribution by that round-trip, and clip 0's exposure lock is taken from the on-distribution decode rather than the raw upload — so external seeds don't blow out or drift.
- `fasth3_image.py`: a pure, torch-free PIL decoder (uint8 RGB), imported lazily so schema rendering needs no Pillow. Video is deliberately unsupported — a client that wants to continue from a video sends the frame it wants as an image (same anchor logic, no in-process video decoder). Whole-video restyling (Ref2VA/LV2V) stays out of scope: that conditioning was never distilled.

No effect on PR#1: with no seed, the take is plain text-to-video and continuity is unchanged. Verified on the real _run_channel adapter — image-seeded takes stay exposure-locked with no drift over the chain (photo and cartoon seeds), bad uploads refused cleanly. Full suite 542 passes.