### PR TITLE
Chain story scenes on the hosted deployment's extended contract

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -32,13 +32,30 @@ The model is **two queues plus a player**. `enqueue` takes a prompt
 and UUID. Builds consume the generation queue front-first, always (pausing
 only while the playout queue is full); each finished clip crosses into the
 **playout queue** (`clip_generated`), where `play`, `move`, and `pop` give
-the client full positional control. Nothing plays until `play` (this client
-keeps `set_autoplay` off and drives playout itself). Playback streams 24 fps
+the client full positional control. Nothing plays until `play` or autoplay
+(this client keeps `set_autoplay` **on** for millisecond clip handovers and
+curates the playout *front* with `move`). Playback streams 24 fps
 video (`main_video`, 1344×768 at the default
 16:9 canvas) and 48 kHz mono int16 audio (`main_audio`), then flushes to
 black and holds. The metadata is echoed untouched on every message that
 references the clip — it is how a client correlates clips with its own
 records without local joins.
+
+The **hosted deployment, `reactor/fast-h3`, extends that contract**, and
+the client uses the extension when the deployment publishes it
+(`link.supports_continuation`, detected from `state_update`, never assumed
+from the model name): `enqueue` also takes `continue_from_clip_id` — the
+clip opens on the named clip's last frame, and autoplay hands a continuing
+clip over seamlessly (no black, no cut) — plus a `starting_frame` image
+upload (deliberately unused here for now; deferred to a feature where an
+episode contributes the image); built clips stay referenceable through
+`queue_update.history`; `set_flush_on_clip_end` chooses what non-continuing
+boundaries do (this client keeps the default, flush on). The director
+chains a story group's scenes with continuation, so a chunked story plays
+as one uninterrupted video; against the in-repo model everything falls back
+to independent clips with a flush between. The in-repo `fast-h3/` source
+predates the extension and stays as-is — it remains the authoritative
+reference for the base contract only.
 
 The client is a straight pipeline:
 
@@ -51,8 +68,9 @@ chat (Twitch IRC / YouTube API) → Director → Moderator → PromptUpsampler (
 
 One chat prompt becomes one **scene group**: a single scene, or a chunked
 short story of up to `MAX_CHUNKS` short clips — the upsampling LLM picks the
-shape — enqueued contiguously, each clip tagged with a JSON group id in the
-metadata. The director drives playout itself (autoplay off): `pick_next`
+shape — enqueued contiguously (and chained with `continue_from_clip_id` on
+a continuation-capable deployment), each clip tagged with a JSON group id in
+the metadata. The director owns playout order: `pick_next`
 plays viewer content before filler from the playout queue, judged purely
 from the metadata echo, and viewer groups insert into the generation queue
 ahead of waiting filler and behind waiting viewers (`enqueue`'s `position`)
@@ -103,7 +121,18 @@ Director being the queues' only writer (viewer worker, idle filler, and
 4. **Prompts are hard-truncated to 800 chars and scene lengths clamped to
    the live bounds** from `state_update` — never trust the LLM's counting,
    never hardcode bounds the deployment publishes.
-5. **The schema is product surface.** Every `@event`/`InputField`/
+5. **Chained scenes open on described hard cuts.** A clip enqueued with
+   `continue_from_clip_id` opens on the previous clip's final frame; a
+   chain written as one continuous take compounds generation errors link
+   over link until the picture visibly degrades ("cooks"). The upsampler's
+   chained rules therefore make every scene after the first open on an
+   explicit cut to a fully described new shot (different camera angle,
+   distance, or location) and forbid "the camera continues..." phrasing —
+   and the extended surface is only ever used when
+   `link.supports_continuation` says the deployment publishes it. Both
+   halves of this rule are load-bearing: soften the cuts and the stream
+   cooks; send continuation fields blind and the base model refuses them.
+6. **The schema is product surface.** Every `@event`/`InputField`/
    `MessageField` description and `ModelMessage` docstring in `fast-h3/` is
    compiled into the published schema. Describe only what a client can
    observe on the wire (commands, messages, tracks, by wire name in

--- a/skills/reactor-fast-h3-model/SKILL.md
+++ b/skills/reactor-fast-h3-model/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: reactor-fast-h3-model
-description: Full context for the fast-h3 model in this repo — what FastH3/MiniMax-H3 is, how the Reactor Runtime serves it, the queue contract and every design decision behind it, the measured performance profile and its load-bearing tricks, and how to build and run it with the reactor CLI or raw docker. Read before changing anything under fast-h3/, debugging generation speed or crashes, serving the model locally, or writing a client against it.
+description: Full context for the fast-h3 model in this repo — what FastH3/MiniMax-H3 is, how the Reactor Runtime serves it, the queue contract and every design decision behind it, the hosted deployment's extended contract (clip continuation and the hard-cut prompting rule that keeps chains from degrading), the measured performance profile and its load-bearing tricks, and how to build and run it with the reactor CLI or raw docker. Read before changing anything under fast-h3/, debugging generation speed or crashes, serving the model locally, or writing a client against it.
 ---
 
 # The fast-h3 model: full working context
@@ -162,6 +162,69 @@ the broadcast can never disagree; audio is downmixed to mono int16 48 kHz in
 the backend because the transport downmixes anyway and stereo would corrupt
 runtime recordings.
 
+## 3b. The hosted deployment's extended contract — and the one rule that keeps chains watchable
+
+The hosted deployment of this model, **`reactor/fast-h3`**, serves an
+extended build of the contract above. The source in this repo predates the
+extension and stays as-is; this section documents the extension **as a
+client sees it on the wire**, because the streaming client in this repo
+uses it and any agent driving the hosted model must know these rules.
+
+What the extension adds, all client-observable:
+
+- **Clip continuation.** `enqueue` takes `continue_from_clip_id`: the new
+  clip opens on the named clip's last frame and animates forward. The
+  source may be any clip in either queue or in `queue_update.history` — a
+  capped, oldest-evicted list of built clips that already played but stay
+  continuable — and a clip continuing an unbuilt source waits its turn
+  without blocking other builds. When autoplay's next clip continues the
+  one just finished, the handover is **seamless**: no flush, no black, one
+  uninterrupted stream. `ClipInfo` grows `continue_from_clip_id` and
+  `has_starting_frame`; `pop` refuses an unbuilt clip that queued clips
+  still continue from (pop the dependents first); a failed build fails the
+  clips waiting on it, each with its own `clip_failed`.
+- **Starting images.** `enqueue` takes a `starting_frame` upload — the
+  still is fitted to the canvas and animated forward (image-to-video). At
+  most one of `starting_frame` and `continue_from_clip_id` per clip. The
+  streaming client in this repo deliberately does not use this yet
+  (deferred to a feature where an episode contributes the image).
+- **`set_flush_on_clip_end`.** On (default), non-continuing clip
+  boundaries cut to black; off, they hold the last frame. Chained
+  handovers never flush either way; `reset` always clears the tracks.
+
+A client should detect the extension from the fields only it publishes
+(`state_update.flush_on_clip_end`, `queue_update.history`) rather than
+assume it from the model name — the base contract refuses fields it does
+not know.
+
+### The hard-cut rule (do not let an agent skip this)
+
+**Every chained clip's prompt must open on an explicit hard cut to a fully
+described new shot.** A continued clip re-generates from a generated frame:
+chain clips as one continuous take — same shot, camera "continuing" — and
+the generation errors in each link's final frame compound into the next,
+until within a few links the picture visibly smears and degrades beyond
+use (it "cooks"). A hard cut resets that: opening the prompt with a new
+shot — a clearly different camera angle, distance, or location, described
+from scratch — re-establishes the whole image while the chain keeps story
+continuity, so a chain stays sharp indefinitely.
+
+Concretely, when writing or generating prompts for chained clips:
+
+- Open the prompt with the cut itself: "Hard cut to a wide shot of ...",
+  "Cut to: inside the lighthouse, a close-up of ...".
+- Never phrase a chained clip as an extension of the previous shot: no
+  "the camera continues", "still on her face", "the shot lingers", "we
+  keep following".
+- Keep re-describing everything. The model reads only the clip's own text;
+  the inherited last frame carries the picture over, but subjects and
+  setting the text omits still mutate or vanish.
+- When an LLM writes the prompts (the streaming client's upsampler), these
+  rules must be in its system prompt — an unguided LLM writes continuous
+  takes by default, and the stream degrades on air. The upsampler's
+  chained rules in `streaming-client/upsampler.py` are the reference
+  implementation; treat them as load-bearing.
+
 ## 4. The performance profile — every piece is load-bearing
 
 Measured end state on four B200s: **14.4 s per 14.375 s clip (1.0x
@@ -278,6 +341,7 @@ PYTHONPATH=. python -m pytest tests/ -q
 from reactor_sdk import Reactor
 reactor = Reactor("fast-h3", local=True)                                # :8080
 reactor = Reactor("fast-h3", local=True, api_url="http://localhost:8082")  # custom port
+reactor = Reactor("reactor/fast-h3", api_key="rk_...")   # hosted (extended contract, §3b)
 await reactor.connect()                       # second client: connect(session_id=...)
 ```
 

--- a/skills/reactor-streaming-client/SKILL.md
+++ b/skills/reactor-streaming-client/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: reactor-streaming-client
-description: Full context for the streaming client in this repo — the philosophy that splits it from the fast-h3 model, the chat→moderation→upsampling→two-queue→playout pipeline, every load-bearing scheduling policy (viewer priority, FIFO, drops, backpressure), the media path (pacer, sinks, overlay), and how to run and verify it. Read before changing anything under streaming-client/, debugging the broadcast, adding a sink or chat platform, or tuning the prompt/scheduling behaviour.
+description: Full context for the streaming client in this repo — the philosophy that splits it from the fast-h3 model, the chat→moderation→upsampling→two-queue→playout pipeline, every load-bearing scheduling policy (viewer priority, FIFO, drops, backpressure, clip chaining on the hosted extended contract and the hard-cut prompting rule that keeps chains from degrading), the media path (pacer, sinks, overlay), and how to run and verify it. Read before changing anything under streaming-client/, debugging the broadcast, adding a sink or chat platform, or tuning the prompt/scheduling behaviour.
 ---
 
 # The streaming client: full working context
@@ -104,6 +104,25 @@ bit rests:
    playout capacity — see below), and always produces single-scene
    max-length groups — the finest pop granularity, and popping one never
    truncates a story.
+7. **Story groups chain when the deployment can.** Against the hosted
+   `reactor/fast-h3` (detected via `link.supports_continuation` from the
+   fields only the extended contract publishes in `state_update` — never
+   assumed from the model name), each scene after a group's first is
+   enqueued with `continue_from_clip_id` naming the previous scene's clip:
+   it opens on that clip's last frame and autoplay hands the pair over
+   seamlessly, so a chunked story airs as one uninterrupted video. Three
+   sub-rules keep this safe: (a) **every chained scene's prompt opens on a
+   described hard cut** — the upsampler's chained rules, see section 5 —
+   because a chain written as one continuous take compounds generation
+   errors until the picture degrades on air; (b) a chained enqueue refused
+   twice (a reconnect loses the source server-side) degrades to a
+   standalone clip rather than stalling the group; (c) mass pops (the
+   preset-switch flush) remove dependents before their unbuilt sources,
+   since the extended `pop` refuses an unbuilt clip other clips continue
+   from. Against the in-repo model no continuation field is ever sent and
+   groups play back-to-back with a flush between, exactly as before. The
+   extended `starting_frame` upload is deliberately unused (deferred to an
+   episode-image feature).
 
 ### What the two capacities mean to this client
 
@@ -167,6 +186,18 @@ client changing:
   lengths are transition chunks inside stories only. Up to 3 attempts per
   idea, each request-tagged (the gateway caches identical requests), then a
   raw-prompt fallback; over-long output is cut at a sentence boundary.
+  **The chained rules are the newest load-bearing constraint**: when the
+  director will chain a group (`chained=True`, policy 7), the multi-scene
+  rules switch to `_MULTI_SCENE_RULES_CHAINED`, which requires every scene
+  after the first to open on an explicit hard cut to a fully described new
+  shot (different camera angle, distance, or location — "Hard cut to a
+  wide shot of ...") and forbids extending the previous take ("the camera
+  continues...", "still on..."). A chained clip re-generates from a
+  generated frame; one continuous take compounds those errors link over
+  link until the image degrades on air, and the described cut is what
+  resets it. An unguided LLM writes continuous takes by default — never
+  soften or drop these rules, and keep the self-containment rule beside
+  them (the model reads only the scene's own text, chained or not).
 - **Moderator** (`moderator.py`): the *only* safety gate — the upsampler
   deliberately stages ideas faithfully. Own endpoint/key (`MODERATION_*`),
   because inference gateways typically do not expose `/moderations`;
@@ -212,6 +243,14 @@ python main.py                       # everything from .env
   older image every enqueue still works but the mirrors stay empty — if the
   queues log as 0/0 while builds clearly run, the served image predates the
   contract.
+- The **extended contract** (clip continuation, `queue_update.history`,
+  `set_flush_on_clip_end`) is optional on top of that: the connect log line
+  says `continuation supported` or `unsupported`, and everything chained
+  gates on `link.supports_continuation`. The hosted `reactor/fast-h3`
+  supports it (the `.env.example` default); a local `reactor run` of the
+  in-repo model does not, and the client falls back to independent clips
+  on its own — do not "fix" the fallback by sending continuation fields
+  unconditionally.
 
 ## 8. Keeping this skill true
 

--- a/streaming-client/.env.example
+++ b/streaming-client/.env.example
@@ -1,6 +1,11 @@
 # ---------------------------------------------------------------- Reactor ---
-# Model to drive. The client speaks the fast-h3 clip-queue contract.
-REACTOR_MODEL=fast-h3
+# Model to drive. The client speaks the fast-h3 clip-queue contract, and
+# lights up the extended surface — clip continuation, which chains a story's
+# scenes into one uninterrupted video — when the deployment publishes it.
+# Hosted, that deployment is `reactor/fast-h3`. A local `reactor run` of the
+# in-repo model serves as `fast-h3` (independent clips only; the client
+# detects the difference and falls back on its own).
+REACTOR_MODEL=reactor/fast-h3
 # Hosted session: set an API key. Leave empty (and pass --local, or set
 # REACTOR_LOCAL=1) to drive a local `reactor run` instead.
 REACTOR_API_KEY=

--- a/streaming-client/README.md
+++ b/streaming-client/README.md
@@ -70,6 +70,42 @@ flushes to black until the next `play`. Both queues are bounded
 pauses while playout is full) and a full generation queue refuses `enqueue`
 with a `command_error`.
 
+### The hosted deployment's extended contract
+
+The hosted deployment, **`reactor/fast-h3`**, extends that contract, and
+this client uses the extension when it is there:
+
+- **Clip continuation.** `enqueue` also takes `continue_from_clip_id`: the
+  new clip opens on the named clip's last frame, and when autoplay's next
+  clip continues the one just finished the handover is **seamless** — no
+  black, no cut, one uninterrupted video. The source may be any clip in
+  either queue or in `queue_update.history` (built clips stay
+  referenceable for a while after playing, evicted oldest first); a clip
+  continuing an unbuilt source just waits its turn. `pop` refuses an
+  unbuilt clip that queued clips still continue from — pop dependents
+  first (the preset-switch flush does).
+- **Starting images.** `enqueue` also takes a `starting_frame` upload
+  (image-to-video). This client deliberately does not use it yet — it is
+  deferred to a separate feature where an episode contributes the image.
+- **`set_flush_on_clip_end`.** Chooses whether non-continuing clip
+  boundaries cut to black (default) or hold the last frame. This client
+  keeps the default.
+
+The client **detects** the extension from `state_update`
+(`link.supports_continuation`) rather than assuming it from the model
+name: against the original in-repo model every clip stays independent, no
+continuation field is ever sent, and scene groups play back-to-back with a
+flush between — the pre-extension behaviour, intact.
+
+**The one rule that keeps chains watchable: every chained scene opens on a
+described hard cut.** A chained clip re-generates from a generated frame;
+a chain written as one continuous take compounds those generation errors
+link over link until the picture visibly smears ("cooks"). A hard cut to a
+fully described new shot re-establishes the whole image, so the chain
+stays sharp indefinitely. The upsampler's chained rules enforce this (see
+"Prompt upsampling"); never write or prompt a chained scene as "the camera
+continues...".
+
 ## Scene groups
 
 One chat prompt becomes one **scene group**. The upsampler picks the shape
@@ -97,6 +133,15 @@ it coherent:
 3. A group is enqueued only once **all** its scenes fit in the remaining
    capacity, so it can't wedge half-in. Viewer groups may make that room by
    evicting filler clips (see "Idle filler" below).
+4. On a continuation-capable deployment, a group's scenes are **chained**:
+   each scene after the first is enqueued with `continue_from_clip_id`
+   naming the previous scene's clip, so the story plays as one
+   uninterrupted video instead of clips separated by black. Every chained
+   scene's prompt opens on a hard cut (the upsampler's chained rules — see
+   below), which is what keeps a chain from degrading. A chained enqueue
+   refused twice (a reconnect loses the source clip server-side) falls
+   back to a standalone clip: the scene prompts are self-contained, so a
+   lost link costs the seamless handover, never the story.
 
 Each scene's `metadata` carries the group tag as JSON:
 
@@ -122,8 +167,18 @@ JSON bundle in `presets/`; format in `config.py`'s `load_preset`). The
 prompt's rules mirror how fast-h3 actually behaves — keep them intact when
 editing (rationale in the module docstring):
 
-- every scene is an independent clip with **no memory**, so every scene
-  prompt must re-describe the full setting/subjects/style from scratch;
+- the model reads **only the scene's own text**, so every scene prompt must
+  re-describe the full setting/subjects/style from scratch — chained or
+  not, anything the text omits vanishes or mutates;
+- **chained stories are written as cuts**: when the director will chain a
+  group (`chained=True`), the multi-scene rules switch to the chained set —
+  each scene after the first begins on the previous scene's final frame, so
+  its prompt **must open on a hard cut to a fully described new shot**
+  (different camera angle, distance, or location) and must never extend the
+  previous take ("the camera continues...", "still on..."). Holding one
+  take across chained clips compounds generation errors until the image
+  degrades; a described cut re-establishes it. This rule is load-bearing —
+  never soften it;
 - the LLM is asked for < 750 chars but `_sanitize` **hard-truncates to 800**
   (`MAX_PROMPT_CHARS`, the model's server-side cap) because LLMs can't count;
 - fast-h3 renders audio including clear spoken language, so the prompt
@@ -295,11 +350,13 @@ there.
 pip install -r requirements.txt   # ffmpeg must be on PATH for SINK=rtmp
 cp .env.example .env              # fill in keys, style, sink, chat
 
-# Dry run against a local `reactor run`, throwing frames away:
-python main.py --local --sink noop
+# Dry run against a local `reactor run` of ../fast-h3, throwing frames away
+# (local serves the in-repo model as `fast-h3` — set REACTOR_MODEL, or pass it):
+python main.py --local --sink noop --model fast-h3
 
-# Hosted model, streaming to Twitch, prompts from Twitch chat:
-#   .env: REACTOR_API_KEY=rk_..., TWITCH_CHANNEL=yourchannel, STYLE=...
+# Hosted model (`reactor/fast-h3`, the default in .env.example), streaming
+# to Twitch, prompts from Twitch chat:
+#   .env: REACTOR_API_KEY=rk_..., TWITCH_CHANNEL=yourchannel, PRESET=...
 python main.py --sink rtmp --rtmp-url rtmp://live.twitch.tv/app/STREAM_KEY
 
 # YouTube: RTMP_URL=rtmp://a.rtmp.youtube.com/live2/KEY plus
@@ -373,6 +430,14 @@ which took many iterations to stabilize) and from driving the fast-h3 queue:
   budget; every capacity read from `state_update`; pacer/sink never torn
   down on reconnect; sinks never block the event loop; overlays never
   mutate the pacer's frame and stay within a few ms per compose.
+- **Continuation invariants:** the extended surface is gated on
+  `link.supports_continuation` (detected from `state_update`, never assumed
+  from the model name); a continuation field is never sent to a deployment
+  that did not publish the surface; every chained scene's prompt opens on a
+  described hard cut (the upsampler's chained rules — the anti-degradation
+  rule above); a refused chained enqueue degrades to a standalone clip
+  rather than stalling; mass pops (the preset-switch flush) remove
+  dependents before their unbuilt sources.
 - `../fast-h3/fasth3_types.py` is the wire contract. If the model's schema moves
   (new fields, renamed messages), update `reactor_link.py`'s mirror and the
   director's message handling together, and re-check this README's model

--- a/streaming-client/director.py
+++ b/streaming-client/director.py
@@ -23,6 +23,16 @@ knowledge the model deliberately never has. Rules that keep it coherent:
     the playout loop pops one built filler per tick when a full playout
     queue blocks a viewer's build, and the idle filler stands down whenever
     viewer work is pending.
+  * On a deployment that supports continuation (`link.supports_continuation`
+    — the hosted `reactor/fast-h3`), a story group's scenes are chained:
+    each scene after the first is enqueued with `continue_from_clip_id`
+    naming the previous scene's clip, so it opens on that clip's last frame
+    and autoplay hands the pair over seamlessly — one uninterrupted story
+    instead of clips separated by black. The upsampler writes every chained
+    scene to open on a hard cut (see its module docstring for why); the
+    director only wires the chain. A refused chained enqueue falls back to
+    a standalone clip after two retries — the scene prompts are
+    self-contained, so a lost link degrades the handover, never the story.
 
 Every scene carries the group's identity in the clip's `metadata` — an opaque
 string fast-h3 stores and echoes back on every message that references the
@@ -126,9 +136,14 @@ class Director:
                 keep = self._link.playout_clips[0]["clip_id"]
             elif self._link.generation_clips:
                 keep = self._link.generation_clips[0]["clip_id"]
+            # Built (playout) clips first, then the generation queue back to
+            # front: on the extended contract `pop` refuses an unbuilt clip
+            # that queued clips still continue from, so dependents must go
+            # before their sources.
             doomed = [
                 clip
-                for clip in self._link.generation_clips + self._link.playout_clips
+                for clip in self._link.playout_clips
+                + list(reversed(self._link.generation_clips))
                 if clip["clip_id"] != keep
             ]
             popped = 0
@@ -210,6 +225,7 @@ class Director:
                     source=prompt.source,
                     min_seconds=self._link.min_seconds,
                     max_seconds=self._link.max_seconds,
+                    chained=self._link.supports_continuation,
                 )
                 await self._enqueue_group(group)
             except asyncio.CancelledError:
@@ -347,6 +363,13 @@ class Director:
         the group is dropped with the queues intact — a backlog full of
         viewer content takes no more, rather than stalling every later
         prompt behind a wait.
+
+        On a continuation-capable deployment, each scene after the first
+        continues the previous scene's clip (`continue_from_clip_id`), so
+        the group plays as one uninterrupted story. The chain is dropped
+        per scene after two refused attempts — a source clip lost to a
+        reconnect must not stall the group — and the scene enqueues as a
+        standalone clip instead (a hard cut, which its prompt already is).
         """
         scene_count = len(group.scenes)
         async with self._enqueue_lock:
@@ -373,6 +396,8 @@ class Director:
                 None if group.generated
                 else viewer_insert_position(self._link.generation_clips)
             )
+            chain = self._link.supports_continuation
+            previous_clip_id: str | None = None
             for index, scene in enumerate(group.scenes, start=1):
                 metadata = json.dumps(
                     {
@@ -398,19 +423,45 @@ class Director:
                     # Consecutive positions keep the group contiguous and in
                     # scene order, ahead of the filler it displaced.
                     payload["position"] = position + index - 1
+                if chain and previous_clip_id is not None:
+                    # The scene opens on the previous scene's last frame and
+                    # autoplay hands the pair over with no cut to black. The
+                    # scene prompt itself opens on a hard cut (the
+                    # upsampler's chained rules), so the chain stays sharp.
+                    payload["continue_from_clip_id"] = previous_clip_id
+                chained_refusals = 0
                 while True:
                     reply = await self._link.send_command("enqueue", payload)
                     if isinstance(reply, dict) and "clip" in reply:
                         clip = reply["clip"]
                         logger.info(
-                            "[director] queued %s scene %d/%d as %s (%.1fs, seed %s)%s",
+                            "[director] queued %s scene %d/%d as %s (%.1fs, seed %s)%s%s",
                             group.group_id, index, scene_count,
                             clip["clip_id"][:8], clip["seconds"], clip["seed"],
                             " [auto]" if group.generated else "",
+                            f" ← {previous_clip_id[:8]}"
+                            if payload.get("continue_from_clip_id") else "",
                         )
+                        previous_clip_id = clip["clip_id"]
                         break
                     # Bodyless reply = refused (command_error was logged by the
                     # link) or the session dropped mid-command; wait and retry.
+                    if "continue_from_clip_id" in payload:
+                        # A reconnect loses the source clip server-side, and a
+                        # chained enqueue naming it is refused forever. Two
+                        # strikes, then the scene enqueues standalone — its
+                        # prompt is a self-contained cut, so only the seamless
+                        # handover is lost, never the story.
+                        chained_refusals += 1
+                        if chained_refusals >= 2:
+                            del payload["continue_from_clip_id"]
+                            logger.warning(
+                                "[director] %s scene %d/%d: dropping the "
+                                "continuation after %d refusals; enqueueing "
+                                "as a standalone cut",
+                                group.group_id, index, scene_count,
+                                chained_refusals,
+                            )
                     logger.warning(
                         "[director] enqueue of %s scene %d/%d refused; retrying in %.0fs",
                         group.group_id, index, scene_count, _RETRY_DELAY_S,

--- a/streaming-client/reactor_link.py
+++ b/streaming-client/reactor_link.py
@@ -13,7 +13,15 @@
 
 The model contract this speaks is the fast-h3 clip queue (`../fast-h3/fasth3_types.py`
 is the authoritative reference): `enqueue` → `clip_queued`, builds crossing
-into the playout queue on `clip_generated`. Autoplay is on for gapless
+into the playout queue on `clip_generated`. The hosted deployment
+(`reactor/fast-h3`) serves an extended build of that contract — `enqueue`
+additionally takes `continue_from_clip_id` (the clip opens on the named
+clip's last frame), `queue_update` carries a retained `history` of built
+clips that can still be continued from, and `state_update` carries
+`flush_on_clip_end`. The link mirrors all of it and exposes
+`supports_continuation` so the director lights the chaining path up only
+when the deployment actually publishes it; against the original in-repo
+model everything degrades to independent clips. Autoplay is on for gapless
 chaining; the director owns the *order*, curating the playout front with
 `move` from the metadata echo (viewer content before filler — see
 `Director.run_playout`).
@@ -74,6 +82,7 @@ class ReactorLink:
         self.state: dict[str, Any] = dict(_DEFAULT_STATE)
         self.generation_clips: list[dict] = []
         self.playout_clips: list[dict] = []
+        self.history_clips: list[dict] = []
 
     # -------------------------------------------------------------- wiring
 
@@ -117,6 +126,18 @@ class ReactorLink:
         return int(self.state["width"]), int(self.state["height"])
 
     @property
+    def supports_continuation(self) -> bool:
+        """Whether the connected deployment speaks the extended contract.
+
+        The extended surface (`enqueue`'s `continue_from_clip_id`, the
+        `queue_update.history` list) is detected from the fields only it
+        publishes in `state_update` — never assumed from the model name.
+        False against the original in-repo model, where every clip is
+        independent and the client must not send continuation fields.
+        """
+        return "flush_on_clip_end" in self.state
+
+    @property
     def connected(self) -> bool:
         """Whether a session is live right now (commands would go through)."""
         return self._ready.is_set()
@@ -135,6 +156,8 @@ class ReactorLink:
         elif kind == "queue_update":
             self.generation_clips = data.get("generation", [])
             self.playout_clips = data.get("playout", [])
+            # Extended contract only; absent on the original model.
+            self.history_clips = data.get("history", [])
         elif kind == "command_error":
             logger.warning(
                 "[reactor] command refused: %s — %s",
@@ -223,10 +246,11 @@ class ReactorLink:
             self.state = state
         logger.info(
             "[reactor] canvas %dx%d, clip range %.3f-%.3fs, "
-            "generation %d/%d, playout %d/%d",
+            "generation %d/%d, playout %d/%d, continuation %s",
             *self.canvas, self.min_seconds, self.max_seconds,
             self.generation_queued, self.generation_capacity,
             self.playout_queued, self.playout_capacity,
+            "supported" if self.supports_continuation else "unsupported",
         )
 
         # Autoplay on: the model chains the playout queue's front clip the

--- a/streaming-client/upsampler.py
+++ b/streaming-client/upsampler.py
@@ -10,11 +10,27 @@ scene's length in seconds.
 Why the prompt is written the way it is — these rules come from how fast-h3
 actually behaves, so keep them intact when editing:
 
-  * **Every scene is an independent clip with no memory.** The single biggest
-    quality lever. A scene that says "the same forest" renders a *different*
-    forest; each scene must re-describe the entire setting, subjects, light,
-    and style from scratch. (Learned on the earlier story-livestream client,
-    where under-described scenes visibly "lost" characters between cuts.)
+  * **The model reads only the scene's own text.** The single biggest
+    quality lever. Whatever the generation mode, a scene prompt is the only
+    text the model sees for that clip: each scene must re-describe the
+    entire setting, subjects, light, and style from scratch. Without
+    chaining, "the same forest" renders a *different* forest; with chaining
+    the place carries over visually but still mutates unless the text keeps
+    naming it. (Learned on the earlier story-livestream client, where
+    under-described scenes visibly "lost" characters between cuts.)
+  * **Chained scenes must open on a hard cut, and the cut must be
+    described.** On a continuation-capable deployment the director chains a
+    story's scenes: each clip after the first opens on the previous clip's
+    final frame. A chain written as one continuous take degrades visibly —
+    every clip re-generates from a generated frame, small errors compound
+    link over link, and within a few scenes the picture smears beyond use
+    ("cooks"). A hard cut resets that: a scene that opens on a *new shot* —
+    different camera angle, distance, or location, described from scratch —
+    re-establishes the whole image, so the chain stays sharp indefinitely.
+    The chained rules below therefore require every scene after the first
+    to open with an explicit cut to a fully described new shot, and forbid
+    "the camera continues..." / "still on..." phrasing. This rule is
+    load-bearing; never soften it.
   * **800 characters is the model's hard cap per prompt** (`MAX_PROMPT_CHARS`
     in `fasth3_types.py`); the LLM is told 750 to leave headroom, and
     `_sanitize` hard-truncates anyway, because LLMs do not count characters
@@ -71,11 +87,11 @@ every scene prompt, never contradict it:
 {style}
 
 HOW THE VIDEO MODEL WORKS (hard constraints):
-- Each scene becomes ONE independent clip. The model has NO memory between
-  clips: every scene prompt must be fully self-contained and re-describe the
-  entire setting, subjects, lighting, palette, mood, and style — even when
-  nothing changed from the previous scene. Anything you omit will vanish or
-  mutate between scenes.
+- Each scene becomes ONE clip, and the model reads ONLY that scene's text —
+  it never sees the other scene prompts. Every scene prompt must be fully
+  self-contained and re-describe the entire setting, subjects, lighting,
+  palette, mood, and style — even when nothing changed from the previous
+  scene. Anything you omit will vanish or mutate between scenes.
 - Each scene prompt must be under {target_chars} characters. This is a hard
   limit; prefer cutting adjectives over cutting subjects or setting.
 - Each scene has a duration in seconds, between {min_seconds} and
@@ -123,6 +139,35 @@ HOW MANY SCENES, AND HOW LONG — two shapes; pick what the idea calls for:
 - Consecutive scenes play back-to-back as one sequence. Make them feel
   continuous: repeat the shared setting and subjects verbatim enough that
   they read as the same place, and change only what the story moves."""
+
+_MULTI_SCENE_RULES_CHAINED = """\
+HOW MANY SCENES, AND HOW LONG — two shapes; pick what the idea calls for:
+- ONE SCENE: a single clip that ALWAYS runs the full {max_seconds} seconds —
+  never shorter — with room for the scene to build, land, and breathe.
+  Right for a mood, a place, a single action or gag. When in doubt, this.
+- CHUNKED SHORT STORY: 3 to {max_chunks} chunks that read as one story with
+  a setup, a development, and a payoff. Content chunks run 8-{max_seconds}
+  seconds; the short end ({min_seconds}-8 s) is ONLY for transitions — an
+  establishing cut, a reaction beat, a snap punchline — never for a chunk
+  that carries the story. Choose this shape when the idea implies
+  narrative: a journey, a transformation, a chase, a build-up.
+- Never more than {max_chunks} scenes. Do not pad a thin idea into many
+  chunks; a story earns its chunks or it is one full-length scene.
+- The story's scenes are rendered as ONE continuous video: each scene
+  begins on the exact final frame of the scene before it. Because of that,
+  EVERY SCENE AFTER THE FIRST MUST OPEN ON A HARD CUT — a new shot with a
+  clearly different camera angle, distance, or location — and its prompt
+  must describe that new shot in full, as if the camera were set up fresh.
+  Open the prompt with the cut itself, e.g. "Hard cut to a wide shot of
+  ...", "Cut to: inside the lighthouse, a close-up of ...".
+- NEVER write a scene that extends the previous scene's shot. No "the
+  camera continues", "still on her face", "the shot lingers", "we keep
+  following" — holding one take across scenes makes the picture smear and
+  degrade scene over scene, while a clean cut keeps every scene sharp.
+  Cuts are also film language: use them for rhythm, not just hygiene.
+- Even across cuts the story stays continuous: re-describe the same
+  setting and subjects verbatim enough that they read as the same place
+  and cast, and change only what the story moves."""
 
 _SINGLE_SCENE_RULES = """\
 HOW MANY SCENES, AND HOW LONG:
@@ -189,6 +234,7 @@ class PromptUpsampler:
         max_seconds: float,
         generated: bool = False,
         max_chunks: int | None = None,
+        chained: bool = False,
     ) -> SceneGroup:
         """One idea in, one validated scene group out. Never raises.
 
@@ -196,12 +242,18 @@ class PromptUpsampler:
         `state_update`, so the LLM always chooses within what the deployment
         actually accepts. `max_chunks` caps this call below the configured
         ceiling (the idle filler passes 1 so its groups stay one-clip and
-        evictable). On any LLM failure the raw prompt (styled, truncated)
-        becomes a single scene — the stream keeps moving.
+        evictable). `chained` says the director will chain this group's
+        scenes on the model (each clip opening on the previous one's final
+        frame), which switches the multi-scene rules to the chained set:
+        every scene after the first opens on a described hard cut, never a
+        continuation of the same take (see the module docstring for why).
+        On any LLM failure the raw prompt (styled, truncated) becomes a
+        single scene — the stream keeps moving.
         """
         chunk_cap = min(max_chunks or self._max_chunks, self._max_chunks)
+        multi_rules = _MULTI_SCENE_RULES_CHAINED if chained else _MULTI_SCENE_RULES
         scene_count_rules = (
-            _MULTI_SCENE_RULES.format(
+            multi_rules.format(
                 max_chunks=chunk_cap,
                 min_seconds=f"{min_seconds:g}",
                 max_seconds=f"{max_seconds:g}",


### PR DESCRIPTION
## Why

The hosted deployment of fast-h3, `reactor/fast-h3`, serves an extended build of the clip-queue contract: `enqueue` takes `continue_from_clip_id` (the clip opens on the named clip's last frame, and autoplay hands a continuing clip over seamlessly), built clips stay referenceable through `queue_update.history`, and `set_flush_on_clip_end` chooses what non-continuing boundaries do. Until now the client treated every deployment as the base contract, so a chunked short story aired as clips separated by flushes to black. This change makes the client use continuation when the deployment offers it, so a story airs as one uninterrupted video, while staying fully compatible with the original in-repo model.

Continuation has one non-obvious failure mode that this PR treats as a first-class rule: a chain written as one continuous camera take re-generates each clip from a generated frame, and the errors compound link over link until the picture visibly degrades. The fix is prompting, not code — every chained scene must open on an explicit hard cut to a fully described new shot — and it has to live in the upsampler's system prompt and in the docs and skills, or the next LLM (or agent) writes continuous takes by default and the stream cooks on air.

## What Changed

The link now mirrors `queue_update.history` and exposes `supports_continuation`, detected from the fields only the extended contract publishes in `state_update` — never assumed from the model name. The connect log reports it, and everything chained gates on it, so against the in-repo model no continuation field is ever sent and behaviour is unchanged.

The director chains a story group's scenes: each scene after the first is enqueued with `continue_from_clip_id` naming the previous scene's clip. A chained enqueue refused twice (a reconnect loses the source clip server-side) degrades that scene to a standalone clip rather than stalling the group — the scene prompts are self-contained cuts, so only the seamless handover is lost — and the rest of the chain re-anchors on the standalone clip. The preset-switch flush now pops built clips first and the generation queue back to front, because the extended `pop` refuses an unbuilt clip that queued clips still continue from.

The upsampler grows a chained variant of the multi-scene rules, selected when the director will chain the group: every scene after the first opens with the cut itself ("Hard cut to a wide shot of ..."), extending the previous take ("the camera continues", "still on ...") is forbidden, and the self-containment rule stays beside it — the model reads only the scene's own text, chained or not. The rationale is recorded in the module docstring and marked load-bearing.

Docs move in the same change: `.env.example` defaults to `reactor/fast-h3` (with the local fallback explained), the README documents the extended contract and the hard-cut rule, AGENTS.md gains the invariant, and both skills teach it so agents driving the model do not go off route. The extended `starting_frame` upload is deliberately unused for now, deferred to a feature where an episode contributes the image. AGENTS.md's playout description is also corrected to match the code (autoplay on; the director curates the playout front with `move`).

## Verification

- `python3 -m py_compile` over every touched module.
- System-prompt formatting exercised for both rule sets (chained and not).
- Director chaining exercised against a fake link: chains when supported, sends no continuation field when unsupported, and degrades to a standalone clip after two refusals with the chain re-anchoring on it.
- Diff swept for internal-detail leaks: only wire-observable behaviour of the hosted deployment is described.

Made with [Cursor](https://cursor.com)